### PR TITLE
Fix typo in Lean package comment

### DIFF
--- a/pkgs/lean/default.nix
+++ b/pkgs/lean/default.nix
@@ -55,7 +55,7 @@ in
   })
   .overridePythonAttrs (old: {
     # we have to patch in postInstall for the wheel to be extracted to $out.
-    # actually, we could probably could set preferWheel to false for this package too...
+    # actually, we could probably set preferWheel to false for this package too...
     postInstall =
       (old.postInstall or "")
       + ''


### PR DESCRIPTION
## Summary
- fix typographical error in the Lean `default.nix` comment about `preferWheel`

## Testing
- `nix flake check --no-build` *(fails: attribute 'propagatedBuildInputs' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68414580d37c832b852af65b7e480201