### PR TITLE
Update roon-server tar option

### DIFF
--- a/pkgs/roon-server/update.nix
+++ b/pkgs/roon-server/update.nix
@@ -10,7 +10,7 @@ set +o noglob
 
 newHash="\${data[0]}"
 tarPath="\${data[1]}"
-newVersion="$(${lib.getExe pkgs.gnutar} -zxvOf $tarPath RoonServer/VERSION 2> /dev/null | head -n 1)"
+  newVersion="$(${lib.getExe pkgs.gnutar} -jxvOf $tarPath RoonServer/VERSION 2> /dev/null | head -n 1)"
 
 echo $newVersion $newHash $tarPath
 


### PR DESCRIPTION
## Summary
- fix roon-server updater to use bzip2 decompression

## Testing
- `nix flake check --no-build --impure` *(fails: attribute 'propagatedBuildInputs' missing)*

------
https://chatgpt.com/codex/tasks/task_e_684145885374832bbaf8abadf4ed6008