### PR TITLE
Add pythonImportsCheck for nbstripout

### DIFF
--- a/pkgs/nbstripout/default.nix
+++ b/pkgs/nbstripout/default.nix
@@ -42,6 +42,10 @@ python3.pkgs.buildPythonApplication rec {
     testAssets
   ];
 
+  pythonImportsCheck = [
+    "nbstripout"
+  ];
+
   preCheck = ''
     export HOME=$(mktemp -d)
     export PATH=$out/bin:$PATH


### PR DESCRIPTION
## Summary
- add `pythonImportsCheck` to ensure `nbstripout` can be imported during build

## Testing
- `nix build .#nbstripout`


------
https://chatgpt.com/codex/tasks/task_e_684145912e54832b935a75ae149eafe7