### PR TITLE
Add meta.platform filter for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository includes the following packages:
 - `epub2tts` - EPUB to Text-to-Speech converter
 - `lean` - Lean theorem prover
 - `nbstripout` - Strip output from Jupyter notebooks
-- `roon-server` - Roon audio server
+- `roon-server` - Roon audio server (x86_64-linux only)
 - `tod` - Command line interface for Todoist
 
 ## Home Manager Modules

--- a/default.nix
+++ b/default.nix
@@ -5,18 +5,24 @@
 # Having pkgs default to <nixpkgs> is fine though, and it lets you use short
 # commands such as:
 #     nix-build -A mypackage
-{pkgs ? import <nixpkgs> {}}: {
+{pkgs ? import <nixpkgs> {}}:
+let
+  jackLib = import ./lib { inherit pkgs; };
+  packages = {
+    csharpier = pkgs.callPackage ./pkgs/csharpier {};
+    docfx = pkgs.callPackage ./pkgs/docfx {};
+    epub2tts = pkgs.callPackage ./pkgs/epub2tts {};
+    lean = pkgs.callPackage ./pkgs/lean {};
+    nbstripout = pkgs.callPackage ./pkgs/nbstripout {};
+    roon-server = pkgs.callPackage ./pkgs/roon-server {};
+    tod = pkgs.callPackage ./pkgs/tod {};
+  };
+in
+{
   # The `lib`, `modules`, and `overlay` names are special
-  lib = import ./lib {inherit pkgs;}; # functions
+  lib = jackLib; # functions
   modules = import ./modules; # NixOS modules
   homeManagerModules = import ./home-manager; # Home Manager modules
   overlays = import ./overlays; # nixpkgs overlays
-
-  csharpier = pkgs.callPackage ./pkgs/csharpier {};
-  docfx = pkgs.callPackage ./pkgs/docfx {};
-  epub2tts = pkgs.callPackage ./pkgs/epub2tts {};
-  lean = pkgs.callPackage ./pkgs/lean {};
-  nbstripout = pkgs.callPackage ./pkgs/nbstripout {};
-  roon-server = pkgs.callPackage ./pkgs/roon-server {};
-  tod = pkgs.callPackage ./pkgs/tod {};
 }
+// jackLib.filterByPlatforms pkgs.system packages

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,41 @@
 {pkgs}:
 with pkgs.lib; {
   # Add your library functions here
-  #
-  # hexint = x: hexvals.${toLower x};
+
+  /**
+    Filter an attribute set so that it is returned only when the
+    evaluation `system` is included in `systems`.
+
+    Example:
+
+    ```nix
+    myLib.onlyOnSystems ["x86_64-linux" "aarch64-linux"] pkgs.system {
+      foo = ...;
+    }
+    ```
+    will yield the `foo` attribute only on the listed systems.
+  */
+  onlyOnSystems = systems: system: attrs:
+    optionalAttrs (elem system systems) attrs;
+
+  /**
+    Filter an attribute set of packages using each package's
+    `meta.platforms` field. Packages without a `meta.platforms`
+    specification are kept.
+
+    Example:
+
+    ```nix
+    myLib.filterByPlatforms pkgs.system {
+      foo = pkgs.callPackage ./foo {};
+      bar = pkgs.callPackage ./bar {};
+    }
+    ```
+    will omit any package whose `meta.platforms` list does not
+    include the current system.
+  */
+  filterByPlatforms = system: attrs:
+    filterAttrs (_: pkg:
+      let pls = attrByPath ["meta" "platforms"] platforms.all pkg; in
+        elem system pls) attrs;
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,12 +1,16 @@
 {
   # Default overlay with all packages from jackpkgs
-  default = self: super: {
-    csharpier = super.callPackage ../pkgs/csharpier {};
-    docfx = super.callPackage ../pkgs/docfx {};
-    epub2tts = super.callPackage ../pkgs/epub2tts {};
-    lean = super.callPackage ../pkgs/lean {};
-    nbstripout = super.callPackage ../pkgs/nbstripout {};
-    roon-server = super.callPackage ../pkgs/roon-server {};
-    tod = super.callPackage ../pkgs/tod {};
-  };
+  default = self: super:
+    let
+      jackLib = import ../lib { pkgs = super; };
+      packages = {
+        csharpier = super.callPackage ../pkgs/csharpier {};
+        docfx = super.callPackage ../pkgs/docfx {};
+        epub2tts = super.callPackage ../pkgs/epub2tts {};
+        lean = super.callPackage ../pkgs/lean {};
+        nbstripout = super.callPackage ../pkgs/nbstripout {};
+        roon-server = super.callPackage ../pkgs/roon-server {};
+        tod = super.callPackage ../pkgs/tod {};
+      };
+    in jackLib.filterByPlatforms super.system packages;
 }


### PR DESCRIPTION
## Summary
- filter packages by `meta.platforms` via `filterByPlatforms` helper
- use the new helper in package set and overlay
- drop explicit `onlyOnSystems` filtering for `roon-server`

## Testing
- `nix flake check --print-build-logs` *(fails: attribute 'propagatedBuildInputs' missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858c68c3cfc832b8bce487f17a90669