### PR TITLE
feat: ignore ambient pulumi plugins in devshell

### DIFF
--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -62,6 +62,11 @@ in {
             nodePackages.ts-node
             nodePackages.typescript
           ];
+          env = {
+            # Disable discovering additional plugins by examining $PATH.
+            # Pulumi will download the relevant plugin versions instead.
+            PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
+          };
         };
 
         # Contribute this fragment to the composed devshell


### PR DESCRIPTION
## Summary
- set `PULUMI_IGNORE_AMBIENT_PLUGINS=1` in the Pulumi devShell fragment to disable ambient plugins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebdb9da678832b93714dfd448b96ef