### PR TITLE
Editable environment spec logic

### DIFF
--- a/docs/internal/designs/017-editable-environment-spec-logic.md
+++ b/docs/internal/designs/017-editable-environment-spec-logic.md
@@ -52,15 +52,16 @@ The `members` option controls which packages get the editable overlay applied, b
 
 ## Decision
 
-We WILL modify the default spec logic for editable environments to **automatically include all workspace members** when `spec` is null/unset.
+We WILL modify the spec logic for editable environments to **automatically merge all workspace members** into the final spec. This applies whether or not a `spec` is explicitly provided by the user.
 
-### Design Choice: Automatic for Editable Only
+### Design Choice: Always Merge for Editable Environments
 
-When `environment.editable = true` AND `environment.spec = null`:
-- The spec defaults to `workspace.deps.default` **merged with** all workspace members
+When `environment.editable = true`:
+- All workspace members are automatically merged into the final spec
+- User-provided `spec` extras are preserved (they override the base empty list `[]`)
 - This ensures all local packages are installed from the checkout, not the Nix store
 
-When `environment.editable = false` OR `environment.spec` is explicitly set:
+When `environment.editable = false`:
 - Behavior remains unchanged (use provided spec or `workspace.deps.default`)
 
 ### Key Insight: Understanding uv2nix's `deps` Structure
@@ -241,7 +242,7 @@ If `workspace.members` is empty (single-package project), `allMembersSpec` is `{
 - **Eliminates stale import bugs**: Editable environments always use local checkout for all workspace members
 - **Better DX**: "Editable environment" means what users expect — all local code is live
 - **Zero additional configuration**: Works automatically when `editable = true`
-- **Backwards compatible**: Only affects editable environments with null spec
+- **Non-editable environments unchanged**: Only editable environments are affected; non-editable behavior is fully preserved
 
 ### Trade-offs
 


### PR DESCRIPTION
Add ADR-017 to design the auto-inclusion of all workspace members in editable Python environment specs to prevent stale imports.

Previously, when an editable Python environment was configured with a partial `spec`, workspace members not explicitly listed in the `spec` would be installed from the Nix store as non-editable dependencies. This caused stale imports where local code changes were not reflected, leading to confusing debugging and a broken developer experience. This ADR proposes a solution to always merge all workspace members into the final spec for editable environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-40f8e370-318b-4446-8637-fb6b7c49cef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40f8e370-318b-4446-8637-fb6b7c49cef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ADR-017 describing a change to editable Python environment spec logic to prevent stale imports.
> 
> - Proposes always merging all uv2nix workspace members into `spec` when `editable = true`, preserving user extras
> - Leaves non-editable environments unchanged; details implementation in `python.nix`, testing strategy, risks, and rollout considerations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68bee452ee1753c1ff34684c6148deef84fcd389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->