### PR TITLE
Nix workflow permissions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 jobs:
   nix:
     uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main


### PR DESCRIPTION
Add `packages: write` permission to resolve workflow error when calling a reusable workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-5caf9f03-516a-4eb5-b71e-8e69a31c03a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5caf9f03-516a-4eb5-b71e-8e69a31c03a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Nix workflow permission update**
> 
> - Adds `packages: write` to `permissions` in `.github/workflows/nix.yml` to enable package-related actions when invoking the reusable workflow `jmmaloney4/toolbox/.github/workflows/nix.yml@main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cfb010af6eddd7e1894ce677cc0edb2d28b0649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->