### PR TITLE
Checks includeGroups null issue

### DIFF
--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -332,14 +332,11 @@ in {
         isNonEditableEnv = envCfg: envCfg != null && !isEditableEnv envCfg;
 
         # Check if an environment is suitable for CI (non-editable + groups enabled)
+        # Note: envCfg.includeGroups can be null, true, or false (nullOr bool type).
+        # Using `== true` correctly handles all cases: null→false, true→true, false→false.
         isCiEnvCandidate = envCfg:
           isNonEditableEnv envCfg
-          && (
-            # includeGroups explicitly true, or null with editable=false (defaults to false, but we want true for CI)
-            # Since we're checking non-editable envs, includeGroups=null means it defaults to false
-            # So we need explicit includeGroups=true
-            (envCfg.includeGroups or false)
-          );
+          && (envCfg.includeGroups or null) == true;
 
         # Check if a 'dev' environment is configured
         hasDevEnv = configuredEnvs ? dev;


### PR DESCRIPTION
Fix `isCiEnvCandidate` to correctly handle `includeGroups` when its value is `null`.

The previous implementation `(envCfg.includeGroups or false)` failed when `includeGroups` was `null` (its default value), as `or false` only provides a default for *missing* attributes, not `null` values. The fix `(envCfg.includeGroups or null) == true` correctly evaluates `null` as `false`, aligning with the intent that only explicitly `true` values enable CI candidacy.

---
<a href="https://cursor.com/background-agent?bcId=bc-06004add-546e-4c86-9b0e-2e5c06c0f900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06004add-546e-4c86-9b0e-2e5c06c0f900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CI selects only non-editable Python environments with groups explicitly enabled.
> 
> - Updates `isCiEnvCandidate` in `modules/flake-parts/checks.nix` to use `(envCfg.includeGroups or null) == true`, correctly treating `null` as disabled
> - Adds clarifying comments about `nullOr bool` handling for `includeGroups`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e70c68d538c9f0c312e0da43667a823df88802b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->