### PR TITLE
Mypy hook `getExe'`

### DIFF
--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -76,7 +76,7 @@ in {
         settings.hooks.mypy = {
           enable = true;
           package = sysCfg.mypyPackage;
-          entry = "${lib.getExe sysCfg.mypyPackage}";
+          entry = lib.getExe' sysCfg.mypyPackage "mypy";
           files = "\\.py$";
           excludes = ["^nix/" "/node_modules/" "/dist/" "/__pycache__/"];
         };


### PR DESCRIPTION
Use `lib.getExe'` for the mypy hook entry to correctly resolve the `mypy` binary.

---
<a href="https://cursor.com/background-agent?bcId=bc-a939d4f5-e9ee-406a-b754-40a5cc78c32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a939d4f5-e9ee-406a-b754-40a5cc78c32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Nix config change affecting only the pre-commit `mypy` hook command resolution; low blast radius and no security/data impact.
> 
> **Overview**
> Switches the pre-commit `mypy` hook `entry` in `modules/flake-parts/pre-commit.nix` from `lib.getExe` to `lib.getExe' ... "mypy"` so the hook resolves the correct `mypy` binary for the selected `mypyPackage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b3ccad7e47aad587e89652da6951cae68128fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->