### PR TITLE
Add jupyenv-based jupyter module with python and rust kernel support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,10 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    jupyenv = {
+      url = "github:jmmaloney4/jupyenv";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     just-flake = {
       url = "github:juspay/just-flake";
     };

--- a/modules/flake-parts/all.nix
+++ b/modules/flake-parts/all.nix
@@ -8,6 +8,7 @@
     (import ./devshell.nix {inherit jackpkgsInputs;})
     (import ./fmt.nix {inherit jackpkgsInputs;})
     (import ./just.nix {inherit jackpkgsInputs;})
+    (import ./jupyter.nix {inherit jackpkgsInputs;})
     (import ./pre-commit.nix {inherit jackpkgsInputs;})
     (import ./nodejs.nix {inherit jackpkgsInputs;})
     (import ./pulumi.nix {inherit jackpkgsInputs;})

--- a/modules/flake-parts/jupyter.nix
+++ b/modules/flake-parts/jupyter.nix
@@ -1,0 +1,123 @@
+{jackpkgsInputs}: {
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkIf mkEnableOption mkOption types;
+  cfg = config.jackpkgs.jupyter;
+in {
+  imports = [
+    jackpkgsInputs.jupyenv.flakeModule
+  ];
+
+  options = {
+    jackpkgs.jupyter = {
+      enable = mkEnableOption "jackpkgs-jupyter (jupyenv integration)";
+
+      kernelEnv = mkOption {
+        type = types.str;
+        default = "default";
+        description = "Name of the jackpkgs.python environment to use as the Python kernel.";
+      };
+
+      enableRust = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable Rust kernel (evcxr) using fenix.";
+      };
+
+      settings = mkOption {
+        type = types.attrs;
+        default = {
+          port = 8888;
+          token = "";
+          password = "";
+        };
+        description = "JupyterLab server settings (passed to jupyterlab.settings).";
+      };
+
+      packageName = mkOption {
+        type = types.str;
+        default = "jupyter";
+        description = "Name of the generated Jupyter package.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    perSystem = {
+      config,
+      pkgs,
+      inputs,
+      system,
+      ...
+    }: let
+      # Resolve Python environment
+      pythonEnv = config.jackpkgs.outputs.pythonEnvironments.${cfg.kernelEnv};
+
+      # Rust Kernel Setup
+      # Reference: cavinsresearch/zeus nix/rust.nix
+      rustKernel = let
+        fenix = inputs.fenix.packages.${system};
+        # Use stable toolchain
+        toolchain = fenix.stable.toolchain;
+
+        # Darwin fix for cargo/OpenSSL linkage (adapted from zeus)
+        # On macOS, we need to ensure cargo uses the nixpkgs libcurl/openssl
+        # instead of the system one to avoid dyld errors.
+        cargo =
+          if pkgs.stdenv.isDarwin
+          then
+            pkgs.runCommand "cargo-patched" {
+              nativeBuildInputs = [pkgs.darwin.cctools]; # for install_name_tool
+            } ''
+              mkdir -p $out/bin
+              cp ${toolchain}/bin/cargo $out/bin/cargo
+              chmod +w $out/bin/cargo
+              install_name_tool -change /usr/lib/libcurl.4.dylib ${pkgs.curl.out}/lib/libcurl.4.dylib $out/bin/cargo
+              chmod -w $out/bin/cargo
+            ''
+          else toolchain;
+      in {
+        default = true;
+        name = "rust";
+        displayName = "Rust (evcxr)";
+        packages = [
+          pkgs.evcxr
+          cargo
+          fenix.stable.rustc
+          fenix.stable.rust-src
+          fenix.stable.rust-std
+        ];
+      };
+    in {
+      # Critical: propagate pkgs to jupyenv to respect overlays (Issue #5)
+      jupyenv.pkgs = pkgs;
+
+      jupyenv.jupyterlab = {
+        settings = cfg.settings;
+
+        kernels = {
+          python = {
+            ${cfg.kernelEnv} = {
+              displayName = "Python (${cfg.kernelEnv})";
+              env = pythonEnv;
+            };
+          };
+        };
+      };
+
+      jupyenv.jupyterlab.kernels.rust = mkIf cfg.enableRust {
+        evcxr = rustKernel;
+      };
+
+      # Set package name
+      jupyenv.packageName = cfg.packageName;
+
+      # Expose in devShell
+      jackpkgs.shell.packages = [
+        config.packages.${cfg.packageName}
+      ];
+    };
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dev tooling composition and introduces cross-module coupling (Jupyter ↔ Quarto) plus platform-specific wrapper logic, which may break evaluation or runtime behavior if kernel/env names or package outputs don’t line up.
> 
> **Overview**
> Adds a new `jackpkgs.jupyter` flake-parts module (powered by `jupyenv`) that can generate a JupyterLab package using an existing `jackpkgs.outputs.pythonEnvironments.<name>` as the Python kernel, optionally adding an `evcxr` Rust kernel via `fenix` (including a macOS cargo patch), and exposes the resulting package in the devShell.
> 
> Wires this module into the default module set and adds `jupyenv` as a flake input. Updates the Quarto module to wrap `quarto` when Jupyter is enabled, setting `JUPYTER_PATH` and `QUARTO_PYTHON` so Quarto can find the generated kernels/environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db4995a37ecb186ab0ba82cb0d8398780ac93bb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->