### PR TITLE
Python dev tools documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ jackpkgs.python = {
 };
 ```
 
-Or with separate environments for dev and production:
+Or with separate environments for dev and production (requires `mypyPackage` override):
 
 ```nix
 # Separate environments: editable dev + production default
@@ -365,8 +365,12 @@ jackpkgs.python = {
     };
   };
 };
-# Note: With this setup, pre-commit uses the 'default' environment which lacks mypy.
-# To fix, override `mypyPackage`, e.g.: `jackpkgs.pre-commit.mypyPackage = config.jackpkgs.outputs.pythonEnvironments.dev;`
+
+# IMPORTANT: Override mypyPackage to use the dev environment for pre-commit hooks
+# Without this, the mypy hook will fail because 'default' lacks mypy
+perSystem = { config, ... }: {
+  jackpkgs.pre-commit.mypyPackage = config.jackpkgs.outputs.pythonEnvironments.dev;
+};
 ```
 
 **Why is this necessary?**
@@ -381,8 +385,9 @@ jackpkgs.python = {
 | Pattern | `editable` | `includeGroups` | Pre-commit works? |
 |---------|------------|-----------------|-------------------|
 | Production | `false` | `false` (default) | No (no mypy) |
-| Development | `true` | `true` (default) | Yes |
+| Development | `true` | `true` (default) | Yes (if used as default) |
 | CI/Pre-commit | `false` | `true` (explicit) | Yes |
+| Separate prod + dev | `default`: prod, `dev`: editable | — | Requires `mypyPackage` override |
 
 #### Path resolution (project root)
 

--- a/docs/internal/designs/021-python-dev-tools-documentation.md
+++ b/docs/internal/designs/021-python-dev-tools-documentation.md
@@ -62,7 +62,10 @@ Users who want pre-commit hooks (mypy, ruff, etc.) to work should:
    };
    ```
 
-3. **Or use an editable environment for development:**
+3. **Or use separate environments with an explicit `mypyPackage` override:**
+
+   When you want a production-only `default` environment but still need pre-commit hooks to work,
+   override `mypyPackage` to point to an environment that includes dev tools:
 
    ```nix
    jackpkgs.python = {
@@ -80,16 +83,25 @@ Users who want pre-commit hooks (mypy, ruff, etc.) to work should:
        };
      };
    };
+
+   # Override mypyPackage to use the dev environment for pre-commit hooks
+   perSystem = { config, ... }: {
+     jackpkgs.pre-commit.mypyPackage = config.jackpkgs.outputs.pythonEnvironments.dev;
+   };
    ```
+
+   **Important:** Without the `mypyPackage` override, the pre-commit mypy hook will fail because
+   it defaults to using `pythonDefaultEnv` (the `default` environment), which lacks `mypy`.
 
 ## Environment Patterns Summary
 
-| Environment Type | `editable` | `includeGroups` | Use Case |
-|------------------|------------|-----------------|----------|
-| **Production** | `false` | `false` (default) | Deployment, minimal deps |
-| **Development** | `true` | `true` (default) | Local dev, devshell |
-| **CI Checks** | `false` | `true` (explicit) | Hermetic tests, pre-commit |
-| **Default + Hooks** | `false` | `true` (explicit) | Simple setup with working hooks |
+| Environment Type | `editable` | `includeGroups` | Use Case | Pre-commit works? |
+|------------------|------------|-----------------|----------|-------------------|
+| **Production** | `false` | `false` (default) | Deployment, minimal deps | No (no mypy) |
+| **Development** | `true` | `true` (default) | Local dev, devshell | Yes (if used as default) |
+| **CI Checks** | `false` | `true` (explicit) | Hermetic tests, pre-commit | Yes |
+| **Default + Hooks** | `false` | `true` (explicit) | Simple setup with working hooks | Yes |
+| **Separate prod + dev** | `default`: prod, `dev`: editable | — | Production default + dev shell | Requires `mypyPackage` override |
 
 ### Pre-commit Hook Resolution
 


### PR DESCRIPTION
Add documentation and examples to clarify how to configure Python dev tools (e.g., mypy) with pre-commit hooks using `includeGroups`.

---
<a href="https://cursor.com/background-agent?bcId=bc-49219e75-29b5-4e3d-b149-a006377d8c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49219e75-29b5-4e3d-b149-a006377d8c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (README + new ADR) with no code or behavior changes; risk is limited to potential confusion if examples are misapplied.
> 
> **Overview**
> Clarifies Python dev-tool configuration for `pre-commit` by documenting that the `mypy` hook only works when `mypy` is present in the selected Python environment.
> 
> Adds a new README section, **Common Patterns: Dev Tools with Pre-commit**, with `pyproject.toml` and Nix examples showing how to enable dependency groups via `includeGroups = true`, and how to override `jackpkgs.pre-commit.mypyPackage` when using separate prod vs dev environments.
> 
> Introduces ADR `docs/internal/designs/021-python-dev-tools-documentation.md` to capture the rationale, recommended patterns, and the `pythonDefaultEnv`/fallback resolution behavior for the `mypy` hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 882148f7b1d46e12ab832dfdd44e209f8958592a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->