### PR TITLE
Mypy just recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ in {
   - Integrates `just-flake` features; provides a generated `justfile` with:
     - direnv: `just reload` (`direnv reload`)
     - infra: `just auth` (GCloud ADC), `just new-stack <project> <stack>` (Pulumi)
-    - python: `just nbstrip [<notebook>]` (strip outputs)
+    - python: `just nbstrip [<notebook>]` (strip outputs), `just mypy` (per-package type checking)
     - git: `just pre`, `just pre-all` (pre-commit)
     - nix: `just build-all`, `just build-all-verbose` (flake-iter)
+  - **`just mypy`**: Runs mypy on a per-package basis for Python workspaces, avoiding the "source file found twice" error that occurs when running `mypy .` at the monorepo root with PEP 420 namespace packages. The recipe is auto-generated when `jackpkgs.python` is enabled and workspace members are discovered from `[tool.uv.workspace]` in `pyproject.toml`.
   - Options under `jackpkgs.just` to replace tool packages if desired:
-    - `direnvPackage`, `fdPackage`, `flakeIterPackage`, `googleCloudSdkPackage`, `jqPackage`, `nbstripoutPackage`, `preCommitPackage`, `pulumiPackage`
+    - `direnvPackage`, `fdPackage`, `flakeIterPackage`, `googleCloudSdkPackage`, `jqPackage`, `mypyPackage`, `nbstripoutPackage`, `preCommitPackage`, `pulumiPackage`
     - `pulumiBackendUrl` (nullable string)
   - Options under `jackpkgs.gcp`:
     - `iamOrg` (nullable string, default `null`) — GCP IAM organization domain for the `auth` recipe. When set, `just auth` uses `--account=$GCP_ACCOUNT_USER@<domain>` where `GCP_ACCOUNT_USER` defaults to `$USER`. Example: `iamOrg = "example.com";`

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -6,10 +6,52 @@
 }: let
   inherit (lib) mkIf;
   cfg = config.jackpkgs;
+  pythonCfg = config.jackpkgs.python or {};
 
   # Import justfile generation helpers from shared lib
   justfileHelpers = import ../../lib/justfile-helpers.nix {inherit lib;};
   inherit (justfileHelpers) mkRecipe mkRecipeWithParams optionalLines;
+
+  # Validate workspace paths to prevent path traversal and injection attacks
+  # Rejects paths containing "..", starting with "/", or containing newlines
+  validateWorkspacePath = path:
+    if lib.hasInfix ".." path
+    then throw "Invalid workspace path '${path}': contains '..' (path traversal not allowed for security)"
+    else if lib.hasPrefix "/" path
+    then throw "Invalid workspace path '${path}': absolute paths not allowed (must be relative to workspace root)"
+    else if lib.hasInfix "\n" path
+    then throw "Invalid workspace path: contains newline (command injection not allowed)"
+    else path;
+
+  # Expand workspace globs like "tools/*" -> ["tools/hello", "tools/ocr"]
+  expandWorkspaceGlob = workspaceRoot: glob: let
+    validatedGlob = validateWorkspacePath glob;
+  in
+    if lib.hasSuffix "/*" validatedGlob
+    then let
+      dir = lib.removeSuffix "/*" validatedGlob;
+      fullPath = workspaceRoot + "/${dir}";
+      entries =
+        if builtins.pathExists fullPath
+        then builtins.readDir fullPath
+        else {};
+      subdirs = lib.filterAttrs (name: type: type == "directory" && name != "." && name != "..") entries;
+    in
+      map (name: "${dir}/${name}") (lib.attrNames subdirs)
+    else [validatedGlob];
+
+  # Discover Python workspace members from pyproject.toml
+  discoverPythonMembers = workspaceRoot: pyprojectPath: let
+    pyproject = builtins.fromTOML (builtins.readFile pyprojectPath);
+    memberGlobs = pyproject.tool.uv.workspace.members or ["."];
+
+    allMembers = lib.flatten (map (expandWorkspaceGlob workspaceRoot) memberGlobs);
+
+    # Filter for directories with pyproject.toml
+    hasProject = member:
+      builtins.pathExists (workspaceRoot + "/${member}/pyproject.toml");
+  in
+    lib.filter hasProject allMembers;
 in {
   imports = [
     jackpkgsInputs.just-flake.flakeModule
@@ -86,6 +128,18 @@ in {
           defaultText = "config.jackpkgs.pkgs.jq";
           description = "jq package to use.";
         };
+        mypyPackage = mkOption {
+          type = types.package;
+          default = let
+            pythonDefaultEnv =
+              lib.attrByPath ["jackpkgs" "outputs" "pythonDefaultEnv"] null config;
+          in
+            if pythonDefaultEnv != null
+            then pythonDefaultEnv
+            else config.jackpkgs.pkgs.mypy;
+          defaultText = "`jackpkgs.python.environments.default` (when defined) or `config.jackpkgs.pkgs.mypy`";
+          description = "mypy package to use for per-package type checking.";
+        };
         nbstripoutPackage = mkOption {
           type = types.package;
           default = config.jackpkgs.pkgs.nbstripout;
@@ -126,6 +180,42 @@ in {
     }: let
       sysCfg = config.jackpkgs.just; # per-system config scope
       sysCfgQuarto = config.jackpkgs.quarto;
+
+      # Discover Python workspace members if Python module is enabled
+      pythonWorkspaceMembers =
+        if pythonCfg.enable or false && pythonCfg ? workspaceRoot && pythonCfg ? pyprojectPath && pythonCfg.workspaceRoot != null && pythonCfg.pyprojectPath != null
+        then let
+          # Validate and resolve pyprojectPath (string like "./pyproject.toml")
+          validatedPath = validateWorkspacePath pythonCfg.pyprojectPath;
+          resolvedPyprojectPath = pythonCfg.workspaceRoot + "/${validatedPath}";
+        in
+          if builtins.pathExists resolvedPyprojectPath
+          then discoverPythonMembers pythonCfg.workspaceRoot resolvedPyprojectPath
+          else []
+        else [];
+
+      # Generate mypy per-package recipe when Python workspace members exist
+      # This avoids the "source file found twice" error that occurs when running
+      # mypy at the monorepo root with PEP 420 namespace packages
+      mypyPerPackageRecipe =
+        if pythonWorkspaceMembers != []
+        then let
+          mypyBin = lib.getExe' sysCfg.mypyPackage "mypy";
+          # Generate the per-package mypy commands
+          memberCommands = lib.concatMapStringsSep "\n" (member: ''
+    echo "Type-checking ${member}..."
+    (cd "${member}" && ${mypyBin} .)'') pythonWorkspaceMembers;
+        in
+          lib.concatStringsSep "\n" [
+            (mkRecipe "mypy" "Run mypy per-package (avoids 'source file found twice' in monorepos)" [
+                "#!/usr/bin/env bash"
+                "set -euo pipefail"
+              ]
+              true)
+          ]
+          + memberCommands
+          + "\n"
+        else "";
     in {
       just-flake = {
         features = {
@@ -210,7 +300,8 @@ in {
                 "    ${lib.getExe sysCfg.nbstripoutPackage} \"{{notebook}}\""
                 "fi"
               ]
-              true;
+              true
+              + lib.optionalString (mypyPerPackageRecipe != "") ("\n" + mypyPerPackageRecipe);
           };
           git = {
             enable = true;

--- a/tests/module-justfiles.nix
+++ b/tests/module-justfiles.nix
@@ -121,4 +121,23 @@ in {
     auth:
         ${mockGetExe null} auth login --update-adc
   '';
+
+  # Test mypy per-package recipe pattern
+  # This tests the recipe that runs mypy on a per-package basis in Python monorepos
+  # to avoid the "source file found twice" error with PEP 420 namespace packages
+  testMypyPerPackage = mkJustParseTest "mypy-per-package" (
+    (mkRecipe "mypy" "Run mypy per-package (avoids 'source file found twice' in monorepos)" [
+        "#!/usr/bin/env bash"
+        "set -euo pipefail"
+      ]
+      true)
+    + ''
+    echo "Type-checking packages/pkg-a..."
+    (cd "packages/pkg-a" && ${mockGetExe null} .)
+    echo "Type-checking packages/pkg-b..."
+    (cd "packages/pkg-b" && ${mockGetExe null} .)
+    echo "Type-checking tools/cli..."
+    (cd "tools/cli" && ${mockGetExe null} .)''
+    + "\n"
+  );
 }


### PR DESCRIPTION
Add `just mypy` recipe for Python workspaces to enable per-package type checking and avoid "source file found twice" errors.

The existing `mypy .` command run from the monorepo root often fails in Python workspaces using PEP 420 namespace packages because it encounters the same source files multiple times, leading to "source file found twice" errors. Running `mypy` within each package's directory resolves this by providing a distinct view of the namespace for each check.

---
<a href="https://cursor.com/background-agent?bcId=bc-302bd0fd-4ef8-450b-8342-5798f5fd5fef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-302bd0fd-4ef8-450b-8342-5798f5fd5fef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds Nix-eval-time parsing of `pyproject.toml` and dynamic filesystem discovery to generate shell commands; path validation mitigates injection/traversal, but misconfigured workspace paths could still break justfile generation.
> 
> **Overview**
> Adds an auto-generated **`just mypy`** recipe that runs mypy *per Python workspace member* (discovered from `[tool.uv.workspace]` in `pyproject.toml`) to avoid monorepo/PEP 420 duplicate-source errors.
> 
> Extends `jackpkgs.just` with a configurable `mypyPackage` (defaulting to `jackpkgs.python.environments.default` when available), includes workspace path validation/glob expansion to safely build the per-member commands, updates docs, and adds a justfile parse test covering the new recipe pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c91a3de9bbe337d38f5b11a483177c801fe6df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->