### PR TITLE
Treefmt .jj pattern matching

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -55,7 +55,7 @@ with pkgs.lib; rec {
   # Example:
   #
   # myLib.defaultExcludes.treefmt
-  # => ["**/node_modules/**" "**/dist/**" "**/.direnv/**" "**/.jj/**" "**/.venv/**" "**/__pycache__/**" "/nix/**"]
+  # => ["node_modules/**" "dist/**" ".direnv/**" ".jj/**" ".venv/**" "__pycache__/**" "/nix/**"]
   #
   # myLib.defaultExcludes.preCommit
   # => ["/node_modules/" "/dist/" "/.direnv/" "/.jj/" "/.venv/" "/__pycache__/" "^nix/"]
@@ -78,7 +78,7 @@ with pkgs.lib; rec {
     in
       if rootOnly
       then "/${dir.name}/**"
-      else "**/${dir.name}/**")
+      else "${dir.name}/**")
     dirs;
 
   preCommitExcludesFromDirs = dirs:


### PR DESCRIPTION
Fix treefmt exclude patterns to correctly match directories at the repository root.

The `**/` prefix in the previous patterns (e.g., `**/.jj/**`) prevented them from matching directories like `.jj/` located directly at the repository root. Changing the pattern to `${dir.name}/**` (e.g., `.jj/**`) ensures that these directories are correctly excluded at any level, including the root, as per gitignore-style glob behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-7caa300f-4360-472f-a988-e03bcfed4906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7caa300f-4360-472f-a988-e03bcfed4906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to formatting-tool configuration only; impact is limited to which paths `treefmt` skips.
> 
> **Overview**
> Adjusts `treefmt` exclude glob generation in `lib/default.nix` so non-`rootOnly` directories use `${dir.name}/**` (and updates the example), ensuring repo-root directories like `.jj/` are correctly excluded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57dc88b9e91286fbea7c9729336bb3010ddcdb43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->