### PR TITLE
just: add jj-friendly checks and config-driven lint recipes

### DIFF
--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -354,7 +354,7 @@ in {
                   "set -euo pipefail"
                   "system=$(nix eval --impure --raw --expr builtins.currentSystem)"
                   "checks_json=$(nix eval --json \".#checks.\${system}\")"
-                  "for check in $(printf '%s' \"$checks_json\" | ${lib.getExe sysCfg.jqPackage} -r 'keys[]'); do"
+                  "printf '%s' \"$checks_json\" | ${lib.getExe sysCfg.jqPackage} -r 'keys[]' | while IFS= read -r check; do"
                   "  echo \"==> running check: $check\""
                   "  nix build -L \".#checks.\${system}.$check\""
                   "done"
@@ -362,35 +362,36 @@ in {
                 false)
               ""
               (mkRecipeWithParams "lint" [''dry_run="false"''] "Run lint tools from flake config; fixes in place unless dry_run=true" (
-                [
-                  "#!/usr/bin/env bash"
-                  "set -euo pipefail"
-                  "dry_run='{{dry_run}}'"
-                ]
-                ++ (optionalLines (checksOptionsDefined && checksCfg.python.ruff.enable) [
-                  ""
-                  "# ruff (Python linter)"
-                  "if [ \"$dry_run\" = \"true\" ]; then"
-                  "  ${lib.getExe sysCfg.ruffPackage} check ."
-                  "else"
-                  "  ${lib.getExe sysCfg.ruffPackage} check --fix ."
-                  "fi"
-                ])
-                ++ (optionalLines (checksOptionsDefined && checksCfg.python.mypy.enable) [
-                  ""
-                  "# mypy (Python type checker)"
-                  "${lib.getExe sysCfg.mypyPackage} ."
-                ])
-                ++ (optionalLines (checksOptionsDefined && lib.attrByPath ["biome" "lint" "enable"] false checksCfg) [
-                  ""
-                  "# biome (JS/TS linter)"
-                  "if [ \"$dry_run\" = \"true\" ]; then"
-                  "  ${lib.getExe sysCfg.biomePackage} lint ."
-                  "else"
-                  "  ${lib.getExe sysCfg.biomePackage} lint --write ."
-                  "fi"
-                ])
-              ) false)
+                  [
+                    "#!/usr/bin/env bash"
+                    "set -euo pipefail"
+                    "dry_run='{{dry_run}}'"
+                  ]
+                  ++ (optionalLines (checksOptionsDefined && checksCfg.python.ruff.enable) [
+                    ""
+                    "# ruff (Python linter)"
+                    "if [ \"$dry_run\" = \"true\" ]; then"
+                    "  ${lib.getExe sysCfg.ruffPackage} check ."
+                    "else"
+                    "  ${lib.getExe sysCfg.ruffPackage} check --fix ."
+                    "fi"
+                  ])
+                  ++ (optionalLines (checksOptionsDefined && checksCfg.python.mypy.enable) [
+                    ""
+                    "# mypy (Python type checker)"
+                    "${lib.getExe sysCfg.mypyPackage} ."
+                  ])
+                  ++ (optionalLines (checksOptionsDefined && lib.attrByPath ["biome" "lint" "enable"] false checksCfg) [
+                    ""
+                    "# biome (JS/TS linter)"
+                    "if [ \"$dry_run\" = \"true\" ]; then"
+                    "  ${lib.getExe sysCfg.biomePackage} lint ."
+                    "else"
+                    "  ${lib.getExe sysCfg.biomePackage} lint --write ."
+                    "fi"
+                  ])
+                )
+                false)
             ];
           };
           quarto = {


### PR DESCRIPTION
## Summary

- Add `just checks` to run each `checks.<system>.*` derivation individually via `nix build -L`, avoiding `nix flake check` and `pre-commit --all-files` entirely — safe to use in jj worktrees
- Add `just lint [dry_run="false"]` whose body is generated at Nix eval time from `optionalLines` gated on `jackpkgs.checks.*` config flags — only tools that are enabled in config appear in the recipe, and they are addressed by store path so a missing binary fails loudly rather than passing vacuously
- `dry_run="false"` means fix-by-default; pass `dry_run=true` for read-only/CI mode
- Add `ruffPackage`, `mypyPackage`, `biomePackage` options to `options.jackpkgs.just` (defaulting to `config.jackpkgs.pkgs.*`) so lint tools can be overridden per-project
- Adds `options` to module args and `checksOptionsDefined`/`checksCfg` top-level let bindings so the checks module is accessed safely when present
- Existing `pre-all` / pre-commit workflow unchanged for Git users