### PR TITLE
fix: default pytest to importlib mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ in {
     - `python.enable` (bool, default `jackpkgs.python.enable`)
     - `python.mypy.enable` (bool, default `true`), `python.mypy.extraArgs` (list, default `[]`)
     - `python.ruff.enable` (bool, default `true`), `python.ruff.extraArgs` (list, default `["--no-cache"]`)
-    - `python.pytest.enable` (bool, default `true`), `python.pytest.extraArgs` (list, default `[]`)
+    - `python.pytest.enable` (bool, default `true`), `python.pytest.extraArgs` (list, default `["--import-mode=importlib"]`)
     - `python.numpydoc.enable` (bool, **default `false`** - explicit opt-in), `python.numpydoc.extraArgs` (list, default `[]`)
     - `typescript.tsc.enable` (bool, default `jackpkgs.nodejs.enable`), `typescript.tsc.packages`, `typescript.tsc.nodeModules`, `typescript.tsc.extraArgs`
     - `vitest.enable` (bool, default `jackpkgs.nodejs.enable`), `vitest.packages`, `vitest.nodeModules`, `vitest.extraArgs`
@@ -267,7 +267,7 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
 | ---------- | ------------------- | --------------- | ------------ | ---------------------------- |
 | `mypy`     | `mypy`              | `mypy`          | commit       | enabled                      |
 | `ruff`     | `ruff`              | `ruff`          | commit       | enabled                      |
-| `pytest`   | `pytest`            | `pytest`        | **pre-push** | enabled                      |
+| `pytest`   | `pytest`            | `pytest`        | **pre-push** | enabled (`--import-mode=importlib`) |
 | `numpydoc` | `numpydoc`          | `numpydoc`      | commit       | **disabled**                 |
 | `tsc`      | `tsc`               | `tsc`           | commit       | enabled when `nodejs.enable` |
 | `vitest`   | `vitest`            | `vitest`        | **pre-push** | enabled when `nodejs.enable` |

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -47,9 +47,9 @@ in {
 
           extraArgs = mkOption {
             type = types.listOf types.str;
-            default = [];
-            description = "Extra arguments to pass to pytest";
-            example = ["--color=yes" "-v"];
+            default = ["--import-mode=importlib"];
+            description = "Arguments to pass to pytest";
+            example = ["--import-mode=importlib" "--color=yes" "-v"];
           };
         };
 

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -290,13 +290,23 @@ in {
     checks = mkChecks {
       configModule = mkConfigModule {
         pythonEnable = true;
-        extraConfig.jackpkgs.checks.python.pytest.extraArgs = ["--color=yes" "-v"];
+        extraConfig.jackpkgs.checks.python.pytest.extraArgs = ["--import-mode=importlib" "--color=yes" "-v"];
       };
     };
     script = getBuildCommand checks.pytest;
   in {
     expr =
-      hasInfixAll ["PYTHONPATH=" "COVERAGE_FILE=" "pytest" "--color=yes" "-v"] script;
+      hasInfixAll ["PYTHONPATH=" "COVERAGE_FILE=" "pytest" "--import-mode=importlib" "--color=yes" "-v"] script;
+    expected = true;
+  };
+
+  testPythonPytestDefaultUsesImportlib = let
+    checks = mkChecks {
+      configModule = mkConfigModule {pythonEnable = true;};
+    };
+    script = getBuildCommand checks.pytest;
+  in {
+    expr = hasInfixAll ["pytest" "--import-mode=importlib"] script;
     expected = true;
   };
 

--- a/tests/pre-commit.nix
+++ b/tests/pre-commit.nix
@@ -198,6 +198,13 @@ in {
     expected = true;
   };
 
+  testPytestDefaultUsesImportlib = let
+    hooks = getHooks [(mkConfigModule {})];
+  in {
+    expr = hasInfixAll ["pytest" "--import-mode=importlib"] hooks.pytest.entry;
+    expected = true;
+  };
+
   testVitestPrePushStage = let
     hooks = getHooks [(mkConfigModule {})];
   in {


### PR DESCRIPTION
## Summary
- make `jackpkgs.checks.python.pytest.extraArgs` default to `--import-mode=importlib`, which flows through both generated pytest checks and pytest pre-push hooks
- keep pytest args appendable/overridable in repository config and add nix-unit coverage for the new default behavior
- update the README to document the new pytest default and pre-push hook behavior

## Testing
- `nix build .#checks.x86_64-darwin.nix-unit --no-link`