### PR TITLE
feat(pulumi): default devshell output to non-interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
 
   - Provides Pulumi CLI in a devShell fragment: `config.jackpkgs.outputs.pulumiDevShell`.
   - Provides CI devshell: `devShells.ci-pulumi` with minimal dependencies for CI environments.
+  - When enabled, both Pulumi shells export `PULUMI_OPTION_NON_INTERACTIVE=true`, `PULUMI_OPTION_COLOR=never`, and `PULUMI_OPTION_SUPPRESS_PROGRESS=true` for plain, non-interactive CLI output.
   - Options under `jackpkgs.pulumi`:
     - `enable` (bool, default `true`)
     - `backendUrl` (str, required) - Pulumi backend URL

--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,12 @@
             pkgs = import ./tests/pkgs.nix {
               inherit inputs lib;
             };
+            opencode = import ./tests/opencode.nix {
+              inherit inputs lib;
+            };
+            pulumi = import ./tests/pulumi.nix {
+              inherit inputs lib;
+            };
           };
         };
 

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -138,6 +138,9 @@ in {
           PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
           PULUMI_BACKEND_URL = cfg.backendUrl;
           PULUMI_SECRETS_PROVIDER = cfg.secretsProvider;
+          PULUMI_OPTION_NON_INTERACTIVE = "true";
+          PULUMI_OPTION_COLOR = "never";
+          PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
         };
 
         # ADC file path for the active gcp.profile (null-safe: only used when profile != null).

--- a/tests/pulumi.nix
+++ b/tests/pulumi.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  inputs,
+}: let
+  system = "x86_64-linux";
+  flakeParts = inputs.flake-parts.lib;
+  libModule = import ../modules/flake-parts/lib.nix {jackpkgsInputs = inputs;};
+  pkgsModule = import ../modules/flake-parts/pkgs.nix {jackpkgsInputs = inputs;};
+  devshellModule = import ../modules/flake-parts/devshell.nix {jackpkgsInputs = inputs;};
+  pulumiModule = import ../modules/flake-parts/pulumi.nix {jackpkgsInputs = inputs;};
+
+  evalFlake = modules:
+    flakeParts.evalFlakeModule {inherit inputs;} {
+      systems = [system];
+      imports = [libModule pkgsModule devshellModule] ++ modules ++ [pulumiModule];
+    };
+
+  getPerSystemCfg = modules: (evalFlake modules).config.perSystem system;
+
+  mkConfigModule = {
+    backendUrl ? "s3://pulumi-state",
+    secretsProvider ? "awskms://alias/pulumi",
+  }: {
+    _module.check = false;
+    jackpkgs.pulumi = {
+      enable = true;
+      inherit backendUrl secretsProvider;
+    };
+  };
+
+  expectedEnv = {
+    PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
+    PULUMI_BACKEND_URL = "s3://pulumi-state";
+    PULUMI_SECRETS_PROVIDER = "awskms://alias/pulumi";
+    PULUMI_OPTION_NON_INTERACTIVE = "true";
+    PULUMI_OPTION_COLOR = "never";
+    PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
+  };
+
+  hasExpectedEnv = drv:
+    lib.all (name: drv.${name} == expectedEnv.${name}) (builtins.attrNames expectedEnv);
+in {
+  testPulumiDevShellSetsPulumiCliDefaults = let
+    perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
+  in {
+    expr = hasExpectedEnv perSystemCfg.jackpkgs.outputs.pulumiDevShell;
+    expected = true;
+  };
+
+  testCiPulumiDevShellSetsPulumiCliDefaults = let
+    perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
+  in {
+    expr = hasExpectedEnv perSystemCfg.devShells.ci-pulumi;
+    expected = true;
+  };
+}


### PR DESCRIPTION
## Summary
- set Pulumi devshell defaults for non-interactive, plain-text CLI output when the Pulumi module is enabled
- reuse the same Pulumi environment for both the main Pulumi shell fragment and the CI Pulumi shell
- add nix tests and README notes covering the new shell defaults

## Testing
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); in { pulumiDevShell = flake.tests.systems.x86_64-linux.pulumi.testPulumiDevShellSetsPulumiCliDefaults.expr; ciPulumi = flake.tests.systems.x86_64-linux.pulumi.testCiPulumiDevShellSetsPulumiCliDefaults.expr; }'`
- `nix flake check --impure` *(currently fails in this repo for unrelated pre-existing overlay/network-dependent issues)*