### PR TITLE
fix(just): align ruffPackage with dev-tools Python env

### DIFF
--- a/lib/python-env-selection.nix
+++ b/lib/python-env-selection.nix
@@ -43,7 +43,7 @@
 in {
   inherit selectPythonEnvWithDevTools;
 
-  selectMypyPackage = {
+  selectDevToolsPackage = {
     pythonCfg ? {},
     pythonWorkspace ? null,
     pythonEnvOutputs ? {},

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -88,13 +88,25 @@ in {
         };
         ruffPackage = mkOption {
           type = types.package;
-          default = config.jackpkgs.pkgs.ruff;
-          defaultText = "config.jackpkgs.pkgs.ruff";
-          description = "ruff package to use for Python linting.";
+          defaultText = ''
+            Dev-tools Python env (same precedence as `checks.nix` / `pre-commit.nix`):
+            1. `jackpkgs.python.environments.dev` if non-editable and `includeGroups = true`
+            2. Any non-editable `jackpkgs.python.environments.*` with `includeGroups = true`
+            3. Auto-created env with `includeGroups = true` (via `pythonWorkspace`)
+            4. `config.jackpkgs.outputs.pythonDefaultEnv` (when defined)
+            5. `config.jackpkgs.pkgs.ruff`
+          '';
+          description = ''
+            ruff package (or Python environment containing ruff) to use for the
+            `just lint` Python lint step.
+
+            Defaults to the same dev-tools environment selection used by
+            `checks.nix` CI checks and pre-commit hooks, preferring a
+            non-editable environment with dependency groups enabled.
+          '';
         };
         mypyPackage = mkOption {
           type = types.package;
-          default = config.jackpkgs.pkgs.mypy;
           defaultText = ''
             Dev-tools Python env (same precedence as `checks.nix` / `pre-commit.nix`):
             1. `jackpkgs.python.environments.dev` if non-editable and `includeGroups = true`
@@ -137,14 +149,14 @@ in {
       sysCfg = config.jackpkgs.just; # per-system config scope
       sysCfgQuarto = config.jackpkgs.quarto;
       checksCfgForRecipes = lib.attrByPath ["jackpkgs" "checks"] {} moduleTop.config;
-      pythonCfgForMypy = cfg.python or {};
-      pythonWorkspaceForMypy = config._module.args.pythonWorkspace or null;
-      pythonEnvOutputsForMypy = let
+      pythonCfgForDevTools = cfg.python or {};
+      pythonWorkspaceForDevTools = config._module.args.pythonWorkspace or null;
+      pythonEnvOutputsForDevTools = let
         fromFlake = lib.attrByPath ["jackpkgs" "outputs" "pythonEnvironments"] {} moduleTop.config;
         fromSystem = lib.attrByPath ["jackpkgs" "outputs" "pythonEnvironments"] {} config;
       in
         fromFlake // fromSystem;
-      pythonDefaultEnvForMypy = let
+      pythonDefaultEnvForDevTools = let
         fromSystem = lib.attrByPath ["jackpkgs" "outputs" "pythonDefaultEnv"] null config;
         fromFlake = lib.attrByPath ["jackpkgs" "outputs" "pythonDefaultEnv"] null moduleTop.config;
       in
@@ -152,14 +164,22 @@ in {
         then fromSystem
         else fromFlake;
       justMypyPackageDefault = pythonEnvHelpers.selectMypyPackage {
-        pythonCfg = pythonCfgForMypy;
-        pythonWorkspace = pythonWorkspaceForMypy;
-        pythonEnvOutputs = pythonEnvOutputsForMypy;
-        pythonDefaultEnv = pythonDefaultEnvForMypy;
+        pythonCfg = pythonCfgForDevTools;
+        pythonWorkspace = pythonWorkspaceForDevTools;
+        pythonEnvOutputs = pythonEnvOutputsForDevTools;
+        pythonDefaultEnv = pythonDefaultEnvForDevTools;
         fallbackPackage = config.jackpkgs.pkgs.mypy;
+      };
+      justRuffPackageDefault = pythonEnvHelpers.selectMypyPackage {
+        pythonCfg = pythonCfgForDevTools;
+        pythonWorkspace = pythonWorkspaceForDevTools;
+        pythonEnvOutputs = pythonEnvOutputsForDevTools;
+        pythonDefaultEnv = pythonDefaultEnvForDevTools;
+        fallbackPackage = config.jackpkgs.pkgs.ruff;
       };
     in {
       jackpkgs.just.mypyPackage = lib.mkDefault justMypyPackageDefault;
+      jackpkgs.just.ruffPackage = lib.mkDefault justRuffPackageDefault;
       just-flake = {
         features = {
           # NOTE: Nix indented strings ('' ... '') strip common leading whitespace

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -163,14 +163,14 @@ in {
         if fromSystem != null
         then fromSystem
         else fromFlake;
-      justMypyPackageDefault = pythonEnvHelpers.selectMypyPackage {
+      justMypyPackageDefault = pythonEnvHelpers.selectDevToolsPackage {
         pythonCfg = pythonCfgForDevTools;
         pythonWorkspace = pythonWorkspaceForDevTools;
         pythonEnvOutputs = pythonEnvOutputsForDevTools;
         pythonDefaultEnv = pythonDefaultEnvForDevTools;
         fallbackPackage = config.jackpkgs.pkgs.mypy;
       };
-      justRuffPackageDefault = pythonEnvHelpers.selectMypyPackage {
+      justRuffPackageDefault = pythonEnvHelpers.selectDevToolsPackage {
         pythonCfg = pythonCfgForDevTools;
         pythonWorkspace = pythonWorkspaceForDevTools;
         pythonEnvOutputs = pythonEnvOutputsForDevTools;

--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -416,7 +416,7 @@ in {
             '')
             vitestPackages}
         ''}";
-        preCommitMypyPackageDefault = pythonEnvHelpers.selectMypyPackage {
+        preCommitMypyPackageDefault = pythonEnvHelpers.selectDevToolsPackage {
           pythonCfg = jackpkgsPythonCfg;
           pythonWorkspace = config._module.args.pythonWorkspace or null;
           pythonEnvOutputs = let


### PR DESCRIPTION
ruffPackage previously defaulted to a standalone `pkgs.ruff`, which could diverge from the version pinned in the project's dev-tools environment or lack access to plugins/configurations available in the environment.

Now uses the same `selectMypyPackage` helper as `mypyPackage`, following the identical precedence chain used by `checks.nix` and `pre-commit.nix`:

1. `jackpkgs.python.environments.dev` if non-editable and `includeGroups = true`
2. Any non-editable `jackpkgs.python.environments.*` with `includeGroups = true`
3. Auto-created env with `includeGroups = true` (via `pythonWorkspace`)
4. `config.jackpkgs.outputs.pythonDefaultEnv` (when defined)
5. `config.jackpkgs.pkgs.ruff` (standalone fallback)

This ensures `just lint` behaves identically to CI and pre-commit hooks for all Python tools.

All 116 nix-unit tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `ruff`/`mypy` executables are resolved for `just lint` and pre-commit defaults, which can alter tool versions and behavior across environments. Scope is limited to developer tooling selection logic.
> 
> **Overview**
> Aligns `just`’s `ruffPackage` default with the same dev-tools Python environment precedence used by CI checks and pre-commit, instead of defaulting directly to `pkgs.ruff`.
> 
> Refactors the shared helper in `lib/python-env-selection.nix` from `selectMypyPackage` to a generic `selectDevToolsPackage`, and updates `just.nix` and `pre-commit.nix` to use it (with tool-specific fallbacks) while clarifying the selection precedence in option docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96580ec2b6f512b1c920aa84f2043984b2d5ded6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->