### PR TITLE
fix(just): skip ruff/mypy when no Python files exist

### DIFF
--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -403,7 +403,7 @@ in {
                   ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.ruff.enable) [
                     ""
                     "# ruff (Python linter)"
-                    "if find . '\\(' -name '*.py' -o -name '*.pyi' '\\)' -not -path '*/.*' -print -quit | grep -q .; then"
+                    "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                     "  printf '%s\\n' \"==> ruff\""
                     "  if [ \"$dry_run\" = \"true\" ]; then"
                     "    ${lib.getExe sysCfg.ruffPackage} check --quiet ."
@@ -415,7 +415,7 @@ in {
                   ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.mypy.enable) [
                     ""
                     "# mypy (Python type checker)"
-                    "if find . '\\(' -name '*.py' -o -name '*.pyi' '\\)' -not -path '*/.*' -print -quit | grep -q .; then"
+                    "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                     "  printf '%s\\n' \"==> mypy\""
                     ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} .''
                     "fi"

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -403,18 +403,22 @@ in {
                   ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.ruff.enable) [
                     ""
                     "# ruff (Python linter)"
-                    "printf '%s\\n' \"==> ruff\""
-                    "if [ \"$dry_run\" = \"true\" ]; then"
-                    "  ${lib.getExe sysCfg.ruffPackage} check --quiet ."
-                    "else"
-                    "  ${lib.getExe sysCfg.ruffPackage} check --fix --quiet ."
+                    "if find . '\\(' -name '*.py' -o -name '*.pyi' '\\)' -not -path '*/.*' -print -quit | grep -q .; then"
+                    "  printf '%s\\n' \"==> ruff\""
+                    "  if [ \"$dry_run\" = \"true\" ]; then"
+                    "    ${lib.getExe sysCfg.ruffPackage} check --quiet ."
+                    "  else"
+                    "    ${lib.getExe sysCfg.ruffPackage} check --fix --quiet ."
+                    "  fi"
                     "fi"
                   ])
                   ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.mypy.enable) [
                     ""
                     "# mypy (Python type checker)"
-                    "printf '%s\\n' \"==> mypy\""
-                    "${lib.getExe' sysCfg.mypyPackage "mypy"} ."
+                    "if find . '\\(' -name '*.py' -o -name '*.pyi' '\\)' -not -path '*/.*' -print -quit | grep -q .; then"
+                    "  printf '%s\\n' \"==> mypy\""
+                    ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} .''
+                    "fi"
                   ])
                   ++ (optionalLines (checksOptionsDefined && lib.attrByPath ["biome" "lint" "enable"] false checksCfgForRecipes) [
                     ""


### PR DESCRIPTION
The `lint` recipe was failing with exit code 2 in TS/JS-only consumers because `mypy .` exits 2 when no `.py`/`.pyi` files exist, and ruff would still run and produce noise.

**Change:** Guard both ruff and mypy behind `fd -q -e py -e pyi` checks so they only execute when there are actual Python source or stub files present.

Generated justfile `lint` recipe now:
- Skips ruff entirely when no `*.py` or `*.pyi` files exist
- Skips mypy entirely when no `*.py` or `*.pyi` files exist
- Biome lint is unaffected (already has its own guard via its `enable` switch)

Uses `fd` (already a module dependency) instead of `find` — respects `.gitignore`, cross-platform, no shell escaping complexity.

No Nix syntax issues — `nix flake check` passes cleanly.


---

> [!NOTE]
> **Low Risk**
> Low risk: only changes `just lint` shell logic to conditionally skip `ruff`/`mypy` when no `*.py`/`*.pyi` files exist, reducing false failures in non-Python repos.
> 
> **Overview**
> Prevents `just lint` from failing/noising in non-Python projects by **guarding the `ruff` and `mypy` steps** behind an `fd` check for `*.py`/`*.pyi` files.
> 
> When no Python files exist, those steps are skipped; `biome` lint behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d3f28b0d04c1b40f540ffd5efc7752e21f27f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
