### PR TITLE
fix(pre-commit): align mypy hook scope with CI checks

### DIFF
--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -461,17 +461,21 @@ in {
             pass_filenames = false;
             entry = let
               mypyPkg = sysCfg.python.mypy.package;
-              # Derive the Python version from the mypy package so we can
-              # set PYTHONPATH to its site-packages.  This matches what
-              # checks.nix does for the CI mypy check derivation.
-              mypyPythonVersion =
-                mypyPkg.pythonVersion
-                  or (lib.versions.majorMinor mypyPkg.version or "3.12");
+              # Resolve the Python interpreter version the same way
+              # checks.nix does (from jackpkgs.python.pythonPackage, not
+              # from the mypy tool package whose .version is the mypy
+              # version, not the Python version).
+              pythonVersion =
+                if jackpkgsPythonCfg ? pythonPackage && jackpkgsPythonCfg.pythonPackage != null
+                then
+                  jackpkgsPythonCfg.pythonPackage.pythonVersion
+                    or (lib.versions.majorMinor jackpkgsPythonCfg.pythonPackage.version or "3.12")
+                else "3.12";
             in
               "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
-                export PYTHONPATH="${mypyPkg}/lib/python${mypyPythonVersion}/site-packages"
-                export MYPY_CACHE_DIR="$TMPDIR/.mypy_cache"
-                ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs}
+                export PYTHONPATH="${mypyPkg}/lib/python${pythonVersion}/site-packages"
+                export MYPY_CACHE_DIR="''${TMPDIR:-/tmp}/.mypy_cache"
+                ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .
               ''}";
             files = "\\.py$";
             excludes = defaultExcludes.preCommit;

--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -453,7 +453,26 @@ in {
           settings.hooks.mypy = {
             enable = checksCfg.python.mypy.enable;
             package = sysCfg.python.mypy.package;
-            entry = "${lib.getExe' sysCfg.python.mypy.package "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs}";
+            # Run mypy on the whole workspace (same scope as `just lint` /
+            # CI checks) instead of per-staged-file.  When pass_filenames is
+            # true (the default) pre-commit passes only the staged file
+            # paths, mypy can't resolve the full type graph, and valid
+            # `# type: ignore` directives get flagged as "unused".
+            pass_filenames = false;
+            entry = let
+              mypyPkg = sysCfg.python.mypy.package;
+              # Derive the Python version from the mypy package so we can
+              # set PYTHONPATH to its site-packages.  This matches what
+              # checks.nix does for the CI mypy check derivation.
+              mypyPythonVersion =
+                mypyPkg.pythonVersion
+                  or (lib.versions.majorMinor mypyPkg.version or "3.12");
+            in
+              "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
+                export PYTHONPATH="${mypyPkg}/lib/python${mypyPythonVersion}/site-packages"
+                export MYPY_CACHE_DIR="$TMPDIR/.mypy_cache"
+                ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs}
+              ''}";
             files = "\\.py$";
             excludes = defaultExcludes.preCommit;
           };

--- a/tests/pre-commit.nix
+++ b/tests/pre-commit.nix
@@ -144,7 +144,7 @@ in {
   testMypyEntrySetsPythonPath = let
     hooks = getHooks [(mkConfigModule {})];
   in {
-    expr = hasInfixAll ["PYTHONPATH=" "MYPY_CACHE_DIR=" "mypy"] hooks.mypy.entry;
+    expr = hasInfixAll ["PYTHONPATH=" "MYPY_CACHE_DIR=" "mypy" " ."] hooks.mypy.entry;
     expected = true;
   };
 

--- a/tests/pre-commit.nix
+++ b/tests/pre-commit.nix
@@ -134,6 +134,20 @@ in {
     expected = true;
   };
 
+  testMypyPassFilenamesFalse = let
+    hooks = getHooks [(mkConfigModule {})];
+  in {
+    expr = hooks.mypy.pass_filenames or true;
+    expected = false;
+  };
+
+  testMypyEntrySetsPythonPath = let
+    hooks = getHooks [(mkConfigModule {})];
+  in {
+    expr = hasInfixAll ["PYTHONPATH=" "MYPY_CACHE_DIR=" "mypy"] hooks.mypy.entry;
+    expected = true;
+  };
+
   testRuffEnabledByDefault = let
     hooks = getHooks [(mkConfigModule {})];
   in {


### PR DESCRIPTION
Fixes #221

## Problem

The pre-commit mypy hook ran with `pass_filenames = true` (default), so it only received the staged file paths. Without the full workspace type graph, mypy couldn't see the errors that `# type: ignore` directives suppress, causing them to be flagged as "unused" and failing the hook. Meanwhile `just lint` / CI runs mypy on the full workspace and these same directives are valid.

## Fix

Set `pass_filenames = false` on the mypy pre-commit hook and wrap the entry in a bash script that:
- Exports `PYTHONPATH` from the mypy package's site-packages, resolved using the configured Python interpreter version (same resolution as `checks.nix`)
- Exports `MYPY_CACHE_DIR` to `${TMPDIR:-/tmp}/.mypy_cache`
- Runs `mypy ... .` (workspace root target), matching the CI `checks.nix` invocation pattern

This gives one source of truth for mypy — the workspace-root invocation — regardless of whether it runs via `just lint`, CI, or pre-commit.

## Changes
- `modules/flake-parts/pre-commit.nix`: mypy hook entry now wrapped in bash with PYTHONPATH; `pass_filenames = false`; explicit `.` target
- `tests/pre-commit.nix`: added `testMypyPassFilenamesFalse` and `testMypyEntrySetsPythonPath`

All nix-unit tests pass.