### PR TITLE
fix(flake-parts): export PULUMI vars via shellHook in devshell

### DIFF
--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -104,7 +104,12 @@ in {
         ++ lib.optionals cfg.welcome.enable (
           lib.optional (cfg.welcome.message != null) ''echo ${lib.escapeShellArg cfg.welcome.message}''
           ++ lib.optional cfg.welcome.showJustHint ''echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
-        );
+        )
+        ++ lib.optional (pulumiCfg != null && pulumiCfg.enable) ''
+          export PULUMI_BACKEND_URL="${pulumiCfg.backendUrl}"
+          export PULUMI_SECRETS_PROVIDER="${pulumiCfg.secretsProvider}"
+          export PULUMI_IGNORE_AMBIENT_PLUGINS="1"
+        '';
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell (
         {

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -106,8 +106,8 @@ in {
           ++ lib.optional cfg.welcome.showJustHint ''echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
         )
         ++ lib.optional (pulumiCfg != null && pulumiCfg.enable) ''
-          export PULUMI_BACKEND_URL="${pulumiCfg.backendUrl}"
-          export PULUMI_SECRETS_PROVIDER="${pulumiCfg.secretsProvider}"
+          export PULUMI_BACKEND_URL=${lib.escapeShellArg pulumiCfg.backendUrl}
+          export PULUMI_SECRETS_PROVIDER=${lib.escapeShellArg pulumiCfg.secretsProvider}
           export PULUMI_IGNORE_AMBIENT_PLUGINS="1"
         '';
     in {

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -108,7 +108,7 @@ in {
         ++ lib.optional (pulumiCfg != null && pulumiCfg.enable) ''
           export PULUMI_BACKEND_URL=${lib.escapeShellArg pulumiCfg.backendUrl}
           export PULUMI_SECRETS_PROVIDER=${lib.escapeShellArg pulumiCfg.secretsProvider}
-          export PULUMI_IGNORE_AMBIENT_PLUGINS="1"
+          export PULUMI_IGNORE_AMBIENT_PLUGINS=1
         '';
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell (

--- a/tests/pulumi.nix
+++ b/tests/pulumi.nix
@@ -110,4 +110,15 @@ in {
       justfile;
     expected = true;
   };
+
+  testPulumiShellHookEscapesValuesWithSpecialChars = let
+    scaryUrl = "s3://bucket/path?query=1&flag=true";
+    scarySecret = "passphrase's complex value";
+  in {
+    expr =
+      # lib.escapeShellArg wraps in single quotes and escapes internal single quotes
+      lib.hasInfix "'" (lib.escapeShellArg scaryUrl)
+      && lib.hasInfix "'" (lib.escapeShellArg scarySecret);
+    expected = true;
+  };
 }


### PR DESCRIPTION
## Problem

The `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER`, and `PULUMI_IGNORE_AMBIENT_PLUGINS` environment variables were not appearing in the composed devShell even when `jackpkgs.pulumi.enable = true`.

## Root Cause

`mkShell` only reliably merges `shellHook` from `inputsFrom` derivations. The `env` attribute passed directly to `mkShell` (`env = pulumiEnv;`) does not reliably merge with the `env` from `inputsFrom` like `pulumiDevShell`. This means the Pulumi vars set in `pulumiDevShell` were being lost.

## Fix

Added explicit `export` statements in `shellHookParts` (alongside the existing GCP env var exports):

```nix
++ lib.optional (pulumiCfg != null && pulumiCfg.enable) ''
  export PULUMI_BACKEND_URL="${pulumiCfg.backendUrl}"
  export PULUMI_SECRETS_PROVIDER="${pulumiCfg.secretsProvider}"
  export PULUMI_IGNORE_AMBIENT_PLUGINS="1"
''
```

The `env = pulumiEnv;` attribute stays as a fallback for direct use of `pulumiDevShell` and the CI shells, but the composed devShell now has reliable shellHook-based exports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts devShell environment setup by exporting Pulumi variables in `shellHook`, with basic test coverage for shell-escaping.
> 
> **Overview**
> Ensures the composed `jackpkgs.outputs.devShell` reliably exports `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER`, and `PULUMI_IGNORE_AMBIENT_PLUGINS` by adding explicit `shellHook` `export` statements when `jackpkgs.pulumi.enable` is set (using `lib.escapeShellArg` for safety).
> 
> Adds a small Nix test to assert Pulumi shellHook values are properly shell-escaped for URLs and secrets containing special characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a8e2c0b4b6e8a42a7c693a848ae6ef010c0da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->