### PR TITLE
fix(checks): run Python tools from workspace root, not per-member

### DIFF
--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -502,7 +502,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running pytest (workspace root)..."
-                (cd ${pythonCfg.workspaceRoot} && pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs} .)
+                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs} .)
               '';
             };
           }
@@ -517,7 +517,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running mypy (workspace root)..."
-                (cd ${pythonCfg.workspaceRoot} && mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .)
+                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .)
               '';
             };
           }
@@ -531,7 +531,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running ruff check (workspace root)..."
-                (cd ${pythonCfg.workspaceRoot} && ruff check ${lib.escapeShellArgs cfg.python.ruff.extraArgs} .)
+                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && ruff check ${lib.escapeShellArgs cfg.python.ruff.extraArgs} .)
               '';
             };
           }
@@ -545,7 +545,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running numpydoc (workspace root)..."
-                (cd ${pythonCfg.workspaceRoot} && python -m numpydoc.hooks.validate_docstrings ${lib.escapeShellArgs cfg.python.numpydoc.extraArgs} .)
+                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && python -m numpydoc.hooks.validate_docstrings ${lib.escapeShellArgs cfg.python.numpydoc.extraArgs} .)
               '';
             };
           }

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -502,7 +502,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running pytest (workspace root)..."
-                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs} .)
+                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs})
               '';
             };
           }

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -492,7 +492,7 @@ in {
         lib.optionalAttrs (cfg.enable && cfg.python.enable && pythonEnvWithDevTools != null && pythonWorkspaceMembers != [])
         (
           lib.optionalAttrs cfg.python.pytest.enable {
-            # pytest check
+            # pytest check (workspace root)
             pytest = mkCheck {
               name = "pytest";
               buildInputs = [pythonEnvWithDevTools];
@@ -500,15 +500,14 @@ in {
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
                 export COVERAGE_FILE=$TMPDIR/.coverage
               '';
-              checkCommands = forEachWorkspaceMember {
-                workspaceRoot = pythonCfg.workspaceRoot;
-                members = pythonWorkspaceMembers;
-                perMemberCommand = "pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs}";
-              };
+              checkCommands = ''
+                echo "Running pytest (workspace root)..."
+                (cd ${pythonCfg.workspaceRoot} && pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs} .)
+              '';
             };
           }
           // lib.optionalAttrs cfg.python.mypy.enable {
-            # mypy check
+            # mypy check (workspace root)
             mypy = mkCheck {
               name = "mypy";
               buildInputs = [pythonEnvWithDevTools];
@@ -516,41 +515,38 @@ in {
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
                 export MYPY_CACHE_DIR=$TMPDIR/.mypy_cache
               '';
-              checkCommands = forEachWorkspaceMember {
-                workspaceRoot = pythonCfg.workspaceRoot;
-                members = pythonWorkspaceMembers;
-                perMemberCommand = "mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .";
-              };
+              checkCommands = ''
+                echo "Running mypy (workspace root)..."
+                (cd ${pythonCfg.workspaceRoot} && mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .)
+              '';
             };
           }
           // lib.optionalAttrs cfg.python.ruff.enable {
-            # ruff check
+            # ruff check (workspace root)
             ruff = mkCheck {
               name = "ruff";
               buildInputs = [pythonEnvWithDevTools];
               setupCommands = ''
                 export RUFF_CACHE_DIR=$TMPDIR/.ruff_cache
               '';
-              checkCommands = forEachWorkspaceMember {
-                workspaceRoot = pythonCfg.workspaceRoot;
-                members = pythonWorkspaceMembers;
-                perMemberCommand = "ruff check ${lib.escapeShellArgs cfg.python.ruff.extraArgs} .";
-              };
+              checkCommands = ''
+                echo "Running ruff check (workspace root)..."
+                (cd ${pythonCfg.workspaceRoot} && ruff check ${lib.escapeShellArgs cfg.python.ruff.extraArgs} .)
+              '';
             };
           }
           // lib.optionalAttrs cfg.python.numpydoc.enable {
-            # numpydoc check
+            # numpydoc check (workspace root)
             numpydoc = mkCheck {
               name = "numpydoc";
               buildInputs = [pythonEnvWithDevTools];
               setupCommands = ''
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
               '';
-              checkCommands = forEachWorkspaceMember {
-                workspaceRoot = pythonCfg.workspaceRoot;
-                members = pythonWorkspaceMembers;
-                perMemberCommand = "python -m numpydoc.hooks.validate_docstrings ${lib.escapeShellArgs cfg.python.numpydoc.extraArgs} .";
-              };
+              checkCommands = ''
+                echo "Running numpydoc (workspace root)..."
+                (cd ${pythonCfg.workspaceRoot} && python -m numpydoc.hooks.validate_docstrings ${lib.escapeShellArgs cfg.python.numpydoc.extraArgs} .)
+              '';
             };
           }
         );

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -259,8 +259,8 @@ in {
   };
 
   # Root-level invocation: all Python tools run from workspace root, not per-member.
-  # Verify that the workspace root path appears in the script and the tool runs
-  # from there (no per-member cd into subdirectories).
+  # Verify that the "Running <tool> (workspace root)..." label appears in the script
+  # and no per-member cd into subdirectories is generated.
   testPythonWorkspaceDiscovery = let
     checks = mkChecks {
       configModule = mkConfigModule {pythonEnable = true;};
@@ -328,6 +328,18 @@ in {
     expected = true;
   };
 
+  testPythonMypyRootInvocation = let
+    checks = mkChecks {
+      configModule = mkConfigModule {pythonEnable = true;};
+    };
+    script = getBuildCommand checks.mypy;
+  in {
+    expr =
+      hasInfixAll ["Running mypy (workspace root)..." "mypy"] script
+      && !lib.hasInfix "/packages/pkg-a" script;
+    expected = true;
+  };
+
   testPythonRuffScript = let
     checks = mkChecks {
       configModule = mkConfigModule {
@@ -338,6 +350,18 @@ in {
     script = getBuildCommand checks.ruff;
   in {
     expr = hasInfixAll ["ruff check" "--no-cache"] script;
+    expected = true;
+  };
+
+  testPythonRuffRootInvocation = let
+    checks = mkChecks {
+      configModule = mkConfigModule {pythonEnable = true;};
+    };
+    script = getBuildCommand checks.ruff;
+  in {
+    expr =
+      hasInfixAll ["Running ruff check (workspace root)..." "ruff check"] script
+      && !lib.hasInfix "/packages/pkg-a" script;
     expected = true;
   };
 
@@ -364,6 +388,21 @@ in {
         " ."
       ]
       script;
+    expected = true;
+  };
+
+  testPythonNumpydocRootInvocation = let
+    checks = mkChecks {
+      configModule = mkConfigModule {
+        pythonEnable = true;
+        extraConfig.jackpkgs.checks.python.numpydoc.enable = true;
+      };
+    };
+    script = getBuildCommand checks.numpydoc;
+  in {
+    expr =
+      hasInfixAll ["Running numpydoc (workspace root)..." "numpydoc"] script
+      && !lib.hasInfix "/packages/pkg-a" script;
     expected = true;
   };
 

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -269,9 +269,9 @@ in {
     script = getBuildCommand checks.pytest;
   in {
     expr =
-      hasInfixAll ["Running pytest (workspace root)..." "pytest"] script
-      && !lib.hasInfix "/packages/pkg-a" script
-      && !lib.hasInfix "/packages/ignored" script;
+      hasInfixAll ["Running pytest (workspace root)..." "(cd "] script
+      && !lib.hasInfix "/packages/" script
+      && !lib.hasInfix "/tools/" script;
     expected = true;
   };
 
@@ -335,8 +335,8 @@ in {
     script = getBuildCommand checks.mypy;
   in {
     expr =
-      hasInfixAll ["Running mypy (workspace root)..." "mypy"] script
-      && !lib.hasInfix "/packages/pkg-a" script;
+      hasInfixAll ["Running mypy (workspace root)..." "&& mypy"] script
+      && !lib.hasInfix "/packages/" script;
     expected = true;
   };
 
@@ -360,8 +360,8 @@ in {
     script = getBuildCommand checks.ruff;
   in {
     expr =
-      hasInfixAll ["Running ruff check (workspace root)..." "ruff check"] script
-      && !lib.hasInfix "/packages/pkg-a" script;
+      hasInfixAll ["Running ruff check (workspace root)..." "&& ruff check"] script
+      && !lib.hasInfix "/packages/" script;
     expected = true;
   };
 
@@ -401,8 +401,8 @@ in {
     script = getBuildCommand checks.numpydoc;
   in {
     expr =
-      hasInfixAll ["Running numpydoc (workspace root)..." "numpydoc"] script
-      && !lib.hasInfix "/packages/pkg-a" script;
+      hasInfixAll ["Running numpydoc (workspace root)..." "python -m numpydoc.hooks.validate_docstrings"] script
+      && !lib.hasInfix "/packages/" script;
     expected = true;
   };
 

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -258,6 +258,9 @@ in {
     expected = true;
   };
 
+  # Root-level invocation: all Python tools run from workspace root, not per-member.
+  # Verify that the workspace root path appears in the script and the tool runs
+  # from there (no per-member cd into subdirectories).
   testPythonWorkspaceDiscovery = let
     checks = mkChecks {
       configModule = mkConfigModule {pythonEnable = true;};
@@ -266,7 +269,8 @@ in {
     script = getBuildCommand checks.pytest;
   in {
     expr =
-      hasInfixAll ["/packages/pkg-a" "/packages/pkg-b" "/tools/cli"] script
+      hasInfixAll ["Running pytest (workspace root)..." "pytest"] script
+      && !lib.hasInfix "/packages/pkg-a" script
       && !lib.hasInfix "/packages/ignored" script;
     expected = true;
   };
@@ -282,7 +286,7 @@ in {
     };
     script = getBuildCommand checks.pytest;
   in {
-    expr = lib.hasInfix "Checking ." script;
+    expr = lib.hasInfix "Running pytest (workspace root)..." script;
     expected = true;
   };
 


### PR DESCRIPTION
## Summary

Closes #225

All four Python tools (mypy, pytest, ruff, numpydoc) now run from the workspace root instead of `forEachWorkspaceMember` cd-ing into each package directory.

## Why

Per-member invocation was **actively harmful** for mypy:

1. The root `pyproject.toml` `[tool.mypy]` config is invisible (mypy reads config from CWD)
2. `mypy_path` doesn't apply, so namespace package resolution breaks
3. Module-level overrides (`follow_imports`, `disable_error_code`) don't apply
4. Cross-package imports resolve via installed packages lacking `py.typed` markers, triggering `import-untyped`

For pytest, ruff, and numpydoc the Nix sandbox doesn't persist tool caches between runs, so the incremental benefit of per-member doesn't apply. Root-level invocation is simpler and consistent with `just lint` / pre-commit.

## Changes

- **checks.nix**: Replace `forEachWorkspaceMember` with single `cd ${workspaceRoot}` invocation for all 4 Python tools
- **tests/checks.nix**: Update `testPythonWorkspaceDiscovery` and `testPythonWorkspaceDefaultMember` to assert root-level patterns instead of per-member patterns

## Test plan

- [x] All nix-unit tests pass (48/48)
- [ ] `nix flake check` in a downstream Python workspace confirms mypy no longer diverges from `just lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI execution semantics for Python checks (pytest/mypy/ruff/numpydoc) from per-package to single root invocation, which may alter what code/config is picked up and which failures surface. Scope is limited to check scripts and associated tests.
> 
> **Overview**
> **Python CI checks now run once from the workspace root** instead of iterating over workspace members. `pytest`, `mypy`, `ruff`, and `numpydoc` checks replace `forEachWorkspaceMember` fan-out with a single `(cd ${workspaceRoot} && <tool> ...)` command and emit a new "Running <tool> (workspace root)..." label.
> 
> Tests are updated to assert root-level invocation (no `/packages/` or `/tools/` per-member `cd`), and new test cases verify root-level patterns for `mypy`, `ruff`, and `numpydoc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6a1051d5ac4d90d1924a401453035b0ca1dbb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->