### PR TITLE
feat(just): add informative header and step labels to auth recipe

### DIFF
--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -194,37 +194,64 @@ in {
             justfile = let
               gcloudExe = lib.getExe sysCfg.googleCloudSdkPackage;
 
+              # Computed display values for auth header
+              adcPath = if cfg.gcp.profile != null
+                then "~/.config/gcloud-profiles/${cfg.gcp.profile}/application_default_credentials.json"
+                else "~/.config/gcloud/application_default_credentials.json";
+              gcpAccountLabel = if cfg.gcp.iamOrg != null
+                then "\${GCP_ACCOUNT_USER:-\$USER}@${cfg.gcp.iamOrg}"
+                else "(selected in browser)";
+
               # Construct auth recipe commands based on configuration
               authCommands =
-                (optionalLines (cfg.gcp.iamOrg != null) [
+                # Header: show what we're targeting
+                [
+                  "echo ''"
+                  "echo -e \"\\033[1mAuthentication Targets\\033[0m\""
+                  "echo \"  GCP Account:  ${gcpAccountLabel}\""
+                ]
+                ++ optionalLines (cfg.gcp.quotaProject != null) [
+                  "echo \"  Billing:       ${cfg.gcp.quotaProject}\""
+                ]
+                ++ optionalLines (cfg.pulumi.enable && cfg.pulumi.backendUrl != null) [
+                  "echo \"  Pulumi:        ${cfg.pulumi.backendUrl}\""
+                ]
+                ++ [
+                  "echo \"  ADC:           ${adcPath}\""
+                  "echo ''"
+                ]
+                # Step 1: GCP login + ADC refresh
+                ++ [
+                  "echo -e \"\\033[1m→ Refreshing GCP credentials & ADC\\033[0m\""
+                ]
+                ++ (optionalLines (cfg.gcp.iamOrg != null) [
                   "GCP_ACCOUNT_USER=\"\${GCP_ACCOUNT_USER:-$USER}\""
                 ])
                 ++ [
                   # Unset GOOGLE_APPLICATION_CREDENTIALS for this call only: when it is set,
                   # gcloud prompts Y/n before overwriting the ADC file even though it would
                   # write to the same location. env -u avoids the interactive prompt.
-                  "env -u GOOGLE_APPLICATION_CREDENTIALS ${lib.getExe sysCfg.googleCloudSdkPackage} auth login --update-adc${lib.optionalString (cfg.gcp.iamOrg != null) " --account=$GCP_ACCOUNT_USER@${cfg.gcp.iamOrg}"}"
+                  "env -u GOOGLE_APPLICATION_CREDENTIALS ${gcloudExe} auth login --update-adc${lib.optionalString (cfg.gcp.iamOrg != null) " --account=$GCP_ACCOUNT_USER@${cfg.gcp.iamOrg}"}"
                 ]
+                # Step 2: Set ADC billing project
                 ++ optionalLines (cfg.gcp.quotaProject != null) [
-                  "${lib.getExe sysCfg.googleCloudSdkPackage} auth application-default set-quota-project ${cfg.gcp.quotaProject}"
+                  "echo ''"
+                  "echo -e \"\\033[1m→ Setting ADC billing project to ${cfg.gcp.quotaProject}\\033[0m\""
+                  "${gcloudExe} auth application-default set-quota-project ${cfg.gcp.quotaProject}"
                 ]
+                # Step 3: Pulumi backend login
                 ++ optionalLines (cfg.pulumi.enable && cfg.pulumi.backendUrl != null) [
+                  "echo ''"
+                  "echo -e \"\\033[1m→ Logging into Pulumi backend\\033[0m\""
                   "${lib.getExe' sysCfg.pulumiPackage "pulumi"} login \"${cfg.pulumi.backendUrl}\""
                 ];
-
-              # Determine if we need a shebang (when iamOrg is set, we need multi-line bash)
-              needsShebang = cfg.gcp.iamOrg != null;
 
               # Build the complete auth recipe using mkRecipe helper
               authRecipe =
                 mkRecipe "auth"
                 "Authenticate with GCP/Pulumi and refresh ADC (set GCP_ACCOUNT_USER to override username)"
-                (
-                  if needsShebang
-                  then ["#!/usr/bin/env bash"] ++ authCommands
-                  else authCommands
-                )
-                true; # echoCommands = true to inject "set -x" for bash recipes
+                (["#!/usr/bin/env bash"] ++ authCommands)
+                false;
 
               # auth-status recipe - shows current GCP authentication status
               # Available when profile isolation is enabled

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -250,7 +250,7 @@ in {
               authRecipe =
                 mkRecipe "auth"
                 "Authenticate with GCP/Pulumi and refresh ADC (set GCP_ACCOUNT_USER to override username)"
-                (["#!/usr/bin/env bash"] ++ authCommands)
+                (["#!/usr/bin/env bash" "set -euo pipefail"] ++ authCommands)
                 false;
 
               # auth-status recipe - shows current GCP authentication status

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -208,7 +208,7 @@ in {
                 [
                   "echo ''"
                   "echo -e \"\\033[1mAuthentication Targets\\033[0m\""
-                  "echo \"  GCP Account:  ${gcpAccountLabel}\""
+                  "echo \"  GCP Account:   ${gcpAccountLabel}\""
                 ]
                 ++ optionalLines (cfg.gcp.quotaProject != null) [
                   "echo \"  Billing:       ${cfg.gcp.quotaProject}\""


### PR DESCRIPTION
## Summary

The `just auth` recipe now prints a bold header showing authentication targets before running any commands, and bold step labels before each action.

**Before:** silent execution with only `set -x` output

**After:**

```
Authentication Targets
  GCP Account:  ${GCP_ACCOUNT_USER:-$USER}@example.com
  Billing:       my-project-123
  Pulumi:        gs://my-bucket
  ADC:           ~/.config/gcloud-profiles/example.com/application_default_credentials.json

→ Refreshing GCP credentials & ADC
[gcloud auth login --update-adc ...]

→ Setting ADC billing project to my-project-123
[gcloud auth application-default set-quota-project ...]

→ Logging into Pulumi backend
[pulumi login ...]
```

## Changes

- **Header banner** (bold) with all auth targets: GCP account, billing project, Pulumi backend URL, and ADC file location
- **Step labels** (bold) before each action so you know what's happening
- **ADC path** computed from `gcp.profile` setting — shows profile-isolated path when configured, default gcloud path otherwise
- Always uses a bash shebang recipe now (previously only when `iamOrg` was set)
- Removed `needsShebang` conditional and `echoCommands = true` (was a no-op), replaced with explicit descriptive output

## Test plan

- [x] `nix flake check --no-build` passes
- [ ] Run `just auth` in a consuming project and verify output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling output/recipe wrapping, with only minor behavioral impact from always running under bash with `set -euo pipefail`.
> 
> **Overview**
> Enhances the `infra` `just auth` recipe to print a bold **Authentication Targets** header (GCP account, optional billing/quota project, optional Pulumi backend, and computed ADC path) and bold step labels before each action.
> 
> Standardizes the recipe to always run as bash with `set -euo pipefail`, removes the conditional shebang/`echoCommands` behavior, and factors `gcloud` invocation through a shared `gcloudExe` variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69dcdee6408822287ca8e114d845d1a19d8b7487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->