### PR TITLE
fix(checks): run Node.js tools from workspace root, not per-member

### DIFF
--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -166,8 +166,8 @@ in {
 
       # Biome lint check
       # Note: Biome formatting is handled separately by the `fmt` module via treefmt.
-      # This check runs `biome lint` (lint only, no format enforcement) per workspace
-      # package, mirroring the same fan-out pattern as `typescript.tsc`.
+      # This check runs `biome lint` (lint only, no format enforcement) from the
+      # workspace root.
       biome.lint = {
         enable = mkOption {
           type = types.bool;
@@ -176,7 +176,7 @@ in {
             Enable Biome lint checks. Disabled by default; opt in with
             `jackpkgs.checks.biome.lint.enable = true;`.
 
-            Runs `biome lint` per workspace package. Biome formatting is handled
+            Runs `biome lint` from the workspace root. Biome formatting is handled
             separately by the `fmt` module (treefmt); this check is lint-only to
             avoid duplicate reporting.
           '';
@@ -577,7 +577,7 @@ in {
               ${jackpkgsLib.mkWorkspaceSymlinks projectRoot tsPackages}
             '';
             checkCommands = ''
-              # Validate node_modules exists before iterating packages.
+              # Validate node_modules exists before running.
               # Allow per-package node_modules (linked by linkNodeModules) as alternative.
               if [ ! -d "node_modules" ] && [ ! -d ${lib.escapeShellArg "${lib.head tsPackages}/node_modules"} ]; then
                 printf '%s\n' \
@@ -596,12 +596,8 @@ in {
                   >&2
                 exit 1
               fi
-              ${forEachWorkspaceMember {
-                workspaceRoot = ".";
-                members = tsPackages;
-                perMemberCommand = "tsc --noEmit ${lib.escapeShellArgs cfg.typescript.tsc.extraArgs}";
-                label = "Type-checking";
-              }}
+              echo "Type-checking (workspace root)..."
+              (cd . && tsc --noEmit ${lib.escapeShellArgs cfg.typescript.tsc.extraArgs})
             '';
           };
         };
@@ -652,17 +648,14 @@ in {
               fi
               export VITEST_BIN
             '';
-            checkCommands = forEachWorkspaceMember {
-              workspaceRoot = ".";
-              members = vitestPackages;
-              label = "Testing";
-              perMemberCommand = ''
-                if [ -n "$VITEST_BIN" ]; then
-                  $VITEST_BIN ${lib.escapeShellArgs cfg.vitest.extraArgs}
-                else
-                  echo "WARNING: Vitest binary not found, skipping."
-                fi'';
-            };
+            checkCommands = ''
+              echo "Testing (workspace root)..."
+              (cd . && if [ -n "$VITEST_BIN" ]; then
+                $VITEST_BIN ${lib.escapeShellArgs cfg.vitest.extraArgs}
+              else
+                echo "WARNING: Vitest binary not found, skipping."
+              fi)
+            '';
           };
         };
       # ============================================================
@@ -721,11 +714,10 @@ in {
               fi
               export BIOME_BIN
             '';
-            checkCommands = forEachWorkspaceMember {
-              workspaceRoot = ".";
-              members = biomePackages;
-              perMemberCommand = ''"$BIOME_BIN" lint ${lib.escapeShellArgs cfg.biome.lint.extraArgs} .'';
-            };
+            checkCommands = ''
+              echo "Linting (workspace root)..."
+              (cd . && "$BIOME_BIN" lint ${lib.escapeShellArgs cfg.biome.lint.extraArgs} .)
+            '';
           };
         };
       beancountChecks =

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -339,8 +339,7 @@ in {
           touch $out
         '';
 
-      # Generic workspace member iterator
- 
+
       # Link node_modules into the sandbox
       # Strategy: link root node_modules, then link per-package node_modules when present.
       # Expected layout from nodejs output derivation:

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -339,7 +339,6 @@ in {
           touch $out
         '';
 
-
       # Link node_modules into the sandbox
       # Strategy: link root node_modules, then link per-package node_modules when present.
       # Expected layout from nodejs output derivation:

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -340,18 +340,7 @@ in {
         '';
 
       # Generic workspace member iterator
-      forEachWorkspaceMember = {
-        workspaceRoot,
-        members,
-        perMemberCommand,
-        label ? "Checking",
-      }:
-        lib.concatMapStringsSep "\n" (member: ''
-          echo "${label} ${member}..."
-          (cd ${lib.escapeShellArg "${workspaceRoot}/${member}"} && ${perMemberCommand})
-        '')
-        members;
-
+ 
       # Link node_modules into the sandbox
       # Strategy: link root node_modules, then link per-package node_modules when present.
       # Expected layout from nodejs output derivation:
@@ -597,7 +586,7 @@ in {
                 exit 1
               fi
               echo "Type-checking (workspace root)..."
-              (cd . && tsc --noEmit ${lib.escapeShellArgs cfg.typescript.tsc.extraArgs})
+              tsc --noEmit ${lib.escapeShellArgs cfg.typescript.tsc.extraArgs}
             '';
           };
         };
@@ -650,11 +639,7 @@ in {
             '';
             checkCommands = ''
               echo "Testing (workspace root)..."
-              (cd . && if [ -n "$VITEST_BIN" ]; then
-                $VITEST_BIN ${lib.escapeShellArgs cfg.vitest.extraArgs}
-              else
-                echo "WARNING: Vitest binary not found, skipping."
-              fi)
+              "$VITEST_BIN" ${lib.escapeShellArgs cfg.vitest.extraArgs} ${lib.escapeShellArgs vitestPackages}
             '';
           };
         };
@@ -716,7 +701,7 @@ in {
             '';
             checkCommands = ''
               echo "Linting (workspace root)..."
-              (cd . && "$BIOME_BIN" lint ${lib.escapeShellArgs cfg.biome.lint.extraArgs} .)
+              "$BIOME_BIN" lint ${lib.escapeShellArgs cfg.biome.lint.extraArgs} ${lib.escapeShellArgs biomePackages}
             '';
           };
         };

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -215,10 +215,12 @@ in {
               gcloudExe = lib.getExe sysCfg.googleCloudSdkPackage;
 
               # Computed display values for auth header
-              adcPath = if cfg.gcp.profile != null
+              adcPath =
+                if cfg.gcp.profile != null
                 then "~/.config/gcloud-profiles/${cfg.gcp.profile}/application_default_credentials.json"
                 else "~/.config/gcloud/application_default_credentials.json";
-              gcpAccountLabel = if cfg.gcp.iamOrg != null
+              gcpAccountLabel =
+                if cfg.gcp.iamOrg != null
                 then "\${GCP_ACCOUNT_USER:-\$USER}@${cfg.gcp.iamOrg}"
                 else "(selected in browser)";
 
@@ -464,7 +466,7 @@ in {
                     "# mypy (Python type checker)"
                     "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                     "  printf '%s\\n' \"==> mypy\""
-                    ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} .''
+                    ''${lib.getExe' sysCfg.mypyPackage "mypy"} .''
                     "fi"
                   ])
                   ++ (optionalLines (checksOptionsDefined && lib.attrByPath ["biome" "lint" "enable"] false checksCfgForRecipes) [

--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -467,16 +467,14 @@ in {
               # version, not the Python version).
               pythonVersion =
                 if jackpkgsPythonCfg ? pythonPackage && jackpkgsPythonCfg.pythonPackage != null
-                then
-                  jackpkgsPythonCfg.pythonPackage.pythonVersion
+                then jackpkgsPythonCfg.pythonPackage.pythonVersion
                     or (lib.versions.majorMinor jackpkgsPythonCfg.pythonPackage.version or "3.12")
                 else "3.12";
-            in
-              "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
-                export PYTHONPATH="${mypyPkg}/lib/python${pythonVersion}/site-packages"
-                export MYPY_CACHE_DIR="''${TMPDIR:-/tmp}/.mypy_cache"
-                ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .
-              ''}";
+            in "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
+              export PYTHONPATH="${mypyPkg}/lib/python${pythonVersion}/site-packages"
+              export MYPY_CACHE_DIR="''${TMPDIR:-/tmp}/.mypy_cache"
+              ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .
+            ''}";
             files = "\\.py$";
             excludes = defaultExcludes.preCommit;
           };

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -797,6 +797,32 @@ in {
     expected = true;
   };
 
+  testBiomeLintScript = let
+    checks = mkChecks {
+      configModule = mkConfigModule {
+        extraConfig.jackpkgs.checks.enable = true;
+        extraConfig.jackpkgs.checks.biome.lint.enable = true;
+        extraConfig.jackpkgs.checks.biome.lint.packages = ["packages/app" "tools/cli"];
+        extraConfig.jackpkgs.checks.biome.lint.extraArgs = ["--max-severity=warn"];
+      };
+      projectRoot = pnpmWorkspace;
+    };
+    script = getBuildCommand checks.biome-lint;
+  in {
+    expr =
+      hasInfixAll [
+        "Linting (workspace root)"
+        "biome"
+        "lint"
+        "--max-severity=warn"
+        "packages/app"
+        "tools/cli"
+      ]
+      script
+      && !lib.hasInfix "Linting packages/" script;
+    expected = true;
+  };
+
   testBeancountSetupEscapesLedgerDirectory = let
     checks = mkChecks {
       configModule = mkConfigModule {

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -563,7 +563,8 @@ in {
         "--pretty"
       ]
       script
-      && !lib.hasInfix "Type-checking packages/" script;
+      && !lib.hasInfix "Type-checking packages/" script
+      && !lib.hasInfix "packages/ignored" script;
     expected = true;
   };
 

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -737,7 +737,8 @@ in {
       ]
       script
       && !lib.hasInfix "Linking node_modules from" script
-      && !lib.hasInfix "Testing packages/" script;
+      && !lib.hasInfix "Testing packages/" script
+      && lib.hasInfix "packages/app" script;
     expected = true;
   };
 

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -558,14 +558,12 @@ in {
   in {
     expr =
       hasInfixAll [
-        "Type-checking packages/app"
-        "Type-checking packages/lib"
-        "Type-checking tools/cli"
+        "Type-checking (workspace root)"
         "tsc --noEmit"
         "--pretty"
       ]
       script
-      && !lib.hasInfix "packages/ignored" script;
+      && !lib.hasInfix "Type-checking packages/" script;
     expected = true;
   };
 
@@ -590,8 +588,8 @@ in {
     script = getBuildCommand checks.tsc;
   in {
     expr =
-      hasInfixAll ["Type-checking infra" "Type-checking tools/hello"] script
-      && !lib.hasInfix "packages/app" script;
+      hasInfixAll ["Type-checking (workspace root)" "tsc --noEmit"] script
+      && !lib.hasInfix "Type-checking packages/" script;
     expected = true;
   };
 
@@ -621,7 +619,7 @@ in {
     };
     script = getBuildCommand checks.tsc;
   in {
-    expr = hasInfixAll ["Type-checking packages/app" "Type-checking packages/lib"] script;
+    expr = hasInfixAll ["Type-checking (workspace root)" "tsc --noEmit"] script;
     expected = true;
   };
 
@@ -729,7 +727,7 @@ in {
     # Note: When nodeModules is null, no PATH export is generated (security: no source-tree binaries)
     expr =
       hasInfixAll [
-        "Testing packages/app"
+        "Testing (workspace root)"
         "vitest"
         "--coverage"
         "cp -R"
@@ -737,7 +735,8 @@ in {
         "cd src"
       ]
       script
-      && !lib.hasInfix "Linking node_modules from" script;
+      && !lib.hasInfix "Linking node_modules from" script
+      && !lib.hasInfix "Testing packages/" script;
     expected = true;
   };
 
@@ -757,7 +756,7 @@ in {
     # Verify PATH is set to Nix store binaries (trusted only, not source tree)
     expr =
       hasInfixAll [
-        "Testing packages/app"
+        "Testing (workspace root)"
         "/node_modules/.bin"
         "export PATH="
       ]


### PR DESCRIPTION
## Summary

Closes #226

All three Node.js ecosystem tools (tsc, vitest, biome lint) now run from the workspace root instead of `forEachWorkspaceMember` cd-ing into each package directory.

## Why

Per-member invocation was unnecessary overhead for all three tools:

### tsc
- `--noEmit` only -- no build artifacts, so `outDir`/`rootDir` are irrelevant
- Compiler options should be uniform across the monorepo; a single root tsconfig enforces consistency
- Cross-package type errors caught in a single pass

### vitest
- Native workspace support via `vitest.workspace.ts` -- a single root invocation discovers all members
- Matches how developers actually run it locally (`vitest` from root, not `cd pkg && vitest`)
- Single aggregated test report instead of N separate outputs

### biome lint
- File-level tool, works identically from root or per-package
- Root invocation matches how developers run it locally

## Changes

- **checks.nix**: Replace `forEachWorkspaceMember` with single root-level `(cd . && <tool>)` invocation for tsc, vitest, and biome lint
- **tests/checks.nix**: Update assertions to expect root-level labels (`"Type-checking (workspace root)..."`, `"Testing (workspace root)..."`) instead of per-member labels (`"Type-checking packages/app"`, etc.)

## Test plan

- [x] All nix-unit tests pass (488/488)
- [ ] `nix flake check` in a downstream Node.js workspace confirms tsc/vitest/biome work correctly with root-level invocation

---

> **Medium Risk**
> Changes CI execution semantics for Node.js checks (tsc/vitest/biome) from per-package to single root invocation, which may alter what code/config is picked up and which failures surface. Scope is limited to check scripts and associated tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution semantics for Node.js checks by moving from per-package runs to a single root invocation, which can alter which configs/files are picked up and the shape of failures. Scope is limited to check script generation and its tests.
> 
> **Overview**
> **Node.js check execution is consolidated to workspace-root runs.** `checks.nix` removes the per-member iterator and now invokes `tsc`, `vitest`, and `biome lint` once from the repo root (passing the selected workspace package paths as args where applicable), with updated messaging/docs.
> 
> **Tests and tooling are aligned to the new behavior.** `tests/checks.nix` updates assertions to expect the root-level labels and adds coverage for the new Biome lint script shape; `just.nix` and `pre-commit.nix` include small formatting-only tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ce3433979edf46729394f6fdb2c7a69ddab2eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->