### PR TITLE
fix(just): use getExe' for ruff binary in lint recipe

### DIFF
--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -455,9 +455,9 @@ in {
                     "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                     "  printf '%s\\n' \"==> ruff\""
                     "  if [ \"$dry_run\" = \"true\" ]; then"
-                    "    ${lib.getExe sysCfg.ruffPackage} check --quiet ."
+                    "    ${lib.getExe' sysCfg.ruffPackage "ruff"} check --quiet ."
                     "  else"
-                    "    ${lib.getExe sysCfg.ruffPackage} check --fix --quiet ."
+                    "    ${lib.getExe' sysCfg.ruffPackage "ruff"} check --fix --quiet ."
                     "  fi"
                     "fi"
                   ])


### PR DESCRIPTION
## Problem

The generated `just lint` recipe uses `lib.getExe sysCfg.ruffPackage` to invoke ruff. When `ruffPackage` is a Python virtualenv (the common case with a dev environment), `lib.getExe` resolves to `.../bin/python` instead of `.../bin/ruff`:

```
==> ruff
/nix/store/.../python-nautilus-dev/bin/python3.12: can't open file '.../check': [Errno 2] No such file or directory
```

Python interprets `check` (the ruff subcommand) as a script filename.

## Fix

Change `lib.getExe` → `lib.getExe' ... "ruff"` on lines 458 and 460, matching the existing mypy pattern on line 469 which already uses `lib.getExe'` with an explicit binary name.

**Before:**
```nix
"${lib.getExe sysCfg.ruffPackage} check --quiet ."
"${lib.getExe sysCfg.ruffPackage} check --fix --quiet ."
```

**After:**
```nix
"${lib.getExe' sysCfg.ruffPackage "ruff"} check --quiet ."
"${lib.getExe' sysCfg.ruffPackage "ruff"} check --fix --quiet ."
```

Fixes #233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the command used to run `ruff` in the generated `just lint` recipe to avoid resolving to `python` when `ruffPackage` is a venv.
> 
> **Overview**
> Fixes the generated `just lint` ruff step to call the explicit `ruff` executable via `lib.getExe' sysCfg.ruffPackage "ruff"` (in both dry-run and fix modes) instead of `lib.getExe`, preventing venv-based `ruffPackage` values from resolving to the Python interpreter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39bfa4753726712a7377fbfa61677a58fd748eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->