### PR TITLE
fix(checks): pass source as derivation attribute for proper sandbox access

### DIFF
--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -327,13 +327,24 @@ in {
         config;
 
       # Generic check factory
+      #
+      # When `src` is set, it is passed as a derivation attribute so Nix tracks
+      # the source as a proper input (available in the sandbox).  The builder
+      # then `cd`s into `$src` — using the env-var expansion avoids
+      # interpolating the bare store path into the command string, which would
+      # produce "without a proper context" warnings and fail under
+      # sandboxed builds (Nix ≥ 2.33).
       mkCheck = {
         name,
         buildInputs ? [],
+        src ? null,
         setupCommands ? "",
         checkCommands,
       }:
-        pkgs.runCommand name {inherit buildInputs;} ''
+        pkgs.runCommand name ({
+          inherit buildInputs;
+        } // lib.optionalAttrs (src != null) {inherit src;}) ''
+          ${lib.optionalString (src != null) ''cd "$src"''}
           ${setupCommands}
           ${checkCommands}
           touch $out
@@ -482,6 +493,7 @@ in {
             # pytest check (workspace root)
             pytest = mkCheck {
               name = "pytest";
+              src = pythonCfg.workspaceRoot;
               buildInputs = [pythonEnvWithDevTools];
               setupCommands = ''
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
@@ -489,7 +501,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running pytest (workspace root)..."
-                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs})
+                pytest ${lib.escapeShellArgs cfg.python.pytest.extraArgs}
               '';
             };
           }
@@ -497,6 +509,7 @@ in {
             # mypy check (workspace root)
             mypy = mkCheck {
               name = "mypy";
+              src = pythonCfg.workspaceRoot;
               buildInputs = [pythonEnvWithDevTools];
               setupCommands = ''
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
@@ -504,7 +517,7 @@ in {
               '';
               checkCommands = ''
                 echo "Running mypy (workspace root)..."
-                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .)
+                mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
               '';
             };
           }
@@ -512,13 +525,14 @@ in {
             # ruff check (workspace root)
             ruff = mkCheck {
               name = "ruff";
+              src = pythonCfg.workspaceRoot;
               buildInputs = [pythonEnvWithDevTools];
               setupCommands = ''
                 export RUFF_CACHE_DIR=$TMPDIR/.ruff_cache
               '';
               checkCommands = ''
                 echo "Running ruff check (workspace root)..."
-                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && ruff check ${lib.escapeShellArgs cfg.python.ruff.extraArgs} .)
+                ruff check ${lib.escapeShellArgs cfg.python.ruff.extraArgs} .
               '';
             };
           }
@@ -526,13 +540,14 @@ in {
             # numpydoc check (workspace root)
             numpydoc = mkCheck {
               name = "numpydoc";
+              src = pythonCfg.workspaceRoot;
               buildInputs = [pythonEnvWithDevTools];
               setupCommands = ''
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
               '';
               checkCommands = ''
                 echo "Running numpydoc (workspace root)..."
-                (cd ${lib.escapeShellArg pythonCfg.workspaceRoot} && python -m numpydoc.hooks.validate_docstrings ${lib.escapeShellArgs cfg.python.numpydoc.extraArgs} .)
+                python -m numpydoc.hooks.validate_docstrings ${lib.escapeShellArgs cfg.python.numpydoc.extraArgs} .
               '';
             };
           }

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -342,8 +342,9 @@ in {
         checkCommands,
       }:
         pkgs.runCommand name ({
-          inherit buildInputs;
-        } // lib.optionalAttrs (src != null) {inherit src;}) ''
+            inherit buildInputs;
+          }
+          // lib.optionalAttrs (src != null) {inherit src;}) ''
           ${lib.optionalString (src != null) ''cd "$src"''}
           ${setupCommands}
           ${checkCommands}
@@ -498,6 +499,7 @@ in {
               setupCommands = ''
                 export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
                 export COVERAGE_FILE=$TMPDIR/.coverage
+                export PYTEST_CACHE_DIR=$TMPDIR/.pytest_cache
               '';
               checkCommands = ''
                 echo "Running pytest (workspace root)..."

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -269,7 +269,7 @@ in {
     script = getBuildCommand checks.pytest;
   in {
     expr =
-      hasInfixAll ["Running pytest (workspace root)..." "(cd "] script
+      hasInfixAll ["Running pytest (workspace root)..." ''cd "$src"''] script
       && !lib.hasInfix "/packages/" script
       && !lib.hasInfix "/tools/" script;
     expected = true;
@@ -335,7 +335,7 @@ in {
     script = getBuildCommand checks.mypy;
   in {
     expr =
-      hasInfixAll ["Running mypy (workspace root)..." "&& mypy"] script
+      hasInfixAll ["Running mypy (workspace root)..." ''cd "$src"''] script
       && !lib.hasInfix "/packages/" script;
     expected = true;
   };
@@ -360,7 +360,7 @@ in {
     script = getBuildCommand checks.ruff;
   in {
     expr =
-      hasInfixAll ["Running ruff check (workspace root)..." "&& ruff check"] script
+      hasInfixAll ["Running ruff check (workspace root)..." ''cd "$src"''] script
       && !lib.hasInfix "/packages/" script;
     expected = true;
   };

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -401,7 +401,7 @@ in {
     script = getBuildCommand checks.numpydoc;
   in {
     expr =
-      hasInfixAll ["Running numpydoc (workspace root)..." "python -m numpydoc.hooks.validate_docstrings"] script
+      hasInfixAll ["Running numpydoc (workspace root)..." ''cd "$src"'' "python -m numpydoc.hooks.validate_docstrings"] script
       && !lib.hasInfix "/packages/" script;
     expected = true;
   };
@@ -898,6 +898,54 @@ in {
   in {
     # Verify the check is a valid derivation
     expr = lib.isDerivation minimalPythonCheck.pytest;
+    expected = true;
+  };
+
+  # ============================================================
+  # Tests for src-as-derivation-attribute fix (sandbox access)
+  # ============================================================
+
+  # Verify that Python checks pass the workspace root as a derivation
+  # attribute (src) so Nix properly tracks it as a sandbox input.
+  testPythonPytestSrcIsDerivationAttr = let
+    checks = mkChecks {
+      configModule = mkConfigModule {pythonEnable = true;};
+    };
+  in {
+    expr = checks.pytest.drvAttrs ? src;
+    expected = true;
+  };
+
+  # Verify that `cd "$src"` appears before setupCommands (PYTHONPATH etc.)
+  # so environment variables are set inside the source directory.
+  testPythonPytestCdsBeforeSetup = let
+    checks = mkChecks {
+      configModule = mkConfigModule {pythonEnable = true;};
+    };
+    script = getBuildCommand checks.pytest;
+    # Split on cd "$src" — the part before must not contain PYTHONPATH
+    parts = lib.splitString ''cd "$src"'' script;
+    beforeCd = lib.head parts;
+  in {
+    expr = !lib.hasInfix "PYTHONPATH=" beforeCd;
+    expected = true;
+  };
+
+  # Verify that checks without `src` (e.g. tsc) do NOT contain `cd "$src"`.
+  # tsc uses `cp -R ${projectRoot} src && cd src` instead.
+  testTscCheckHasNoSrcAttr = let
+    checks = mkChecks {
+      configModule = mkConfigModule {
+        nodejsEnable = true;
+        extraConfig.jackpkgs.checks.typescript.tsc.packages = ["infra"];
+      };
+      projectRoot = noWorkspaceFixture;
+    };
+    script = getBuildCommand checks.tsc;
+  in {
+    expr =
+      !lib.hasInfix ''cd "$src"'' script
+      && !(checks.tsc.drvAttrs ? src);
     expected = true;
   };
 }


### PR DESCRIPTION
## Problem

Python CI checks (pytest, mypy, ruff, numpydoc) fail under Nix >= 2.33 sandboxed builds:

```
cd: /nix/store/...-source: No such file or directory
```

With accompanying warning:

```
warning: Using 'builtins.derivation' to create a derivation named 'mypy' that
references the store path '/nix/store/...-source' without a proper context.
```

## Root Cause

`mkCheck` interpolated the workspace root store path (`pythonCfg.workspaceRoot`) directly into the builder command string via `lib.escapeShellArg`. Because `runCommand` uses `passAsFile = ["buildCommand"]`, the store path ends up in a file written at build time that Nix does not scan for input references. The derivation therefore lacks a proper dependency on the source path, and the sandbox blocks access.

## Fix

Add an optional `src` parameter to `mkCheck`. When set:

1. The source is passed as a **derivation attribute** (`{ inherit src; }`), which Nix properly tracks as an input and mounts in the sandbox.
2. The builder `cd`s into the source via `$src` (env var expansion) rather than interpolating the bare store path into the command string. This avoids the "without a proper context" warning entirely.

All four Python checks now pass `src = pythonCfg.workspaceRoot` and run their tool directly (no subshell `(cd ... && ...)` wrapper).

## What Changed

**modules/flake-parts/checks.nix**
- `mkCheck`: new optional `src ? null` parameter; when set, passed as derivation attribute and `cd "$src"` prepended to builder
- pytest, mypy, ruff, numpydoc: pass `src = pythonCfg.workspaceRoot`, remove subshell cd wrapper

**tests/checks.nix**
- Updated 3 test assertions to match new script shape (`cd "$src"` instead of `(cd <path> && tool)`)

## Testing

- `nix flake check -L` passes (all checks including nix-unit 123/123)
- No changes to TypeScript/Vitest/Biome/Beancount checks (they already use `cp -R` which works for their writable-source needs)

## Notes

The TypeScript checks (`tsc`, `vitest`, `biome-lint`) do `cp -R ${projectRoot} src` inline, which interpolates the same store path into the build command. They likely have the same underlying context issue but work by accident when the path is already in the local store. A follow-up could migrate them to use `src` as well, but they need a writable copy (for symlinks) so the read-only `$src` approach doesn't apply directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `mkCheck` constructs derivations and how Python checks run, which can affect CI behavior and sandbox input tracking, but is limited to check execution scripts.
> 
> **Overview**
> **Fixes Nix ≥ 2.33 sandbox issues for Python checks.** `mkCheck` now accepts an optional `src` and, when provided, passes it as a derivation attribute and prepends `cd "$src"` to the builder so the source is a tracked sandbox input.
> 
> Python checks (`pytest`, `mypy`, `ruff`, `numpydoc`) now set `src = pythonCfg.workspaceRoot` and run tools directly from the workspace root (no subshell `cd` wrapper); `pytest` also sets `PYTEST_CACHE_DIR`.
> 
> Tests were updated to assert the new `cd "$src"` script shape and expanded with coverage ensuring `src` is present for Python checks and absent for non-`src` checks like `tsc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b50c731bce758dd996b0c6be9baec9e7a8821c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->