### PR TITLE
feat(fmt): add shfmt and shellcheck via treefmt-nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ in {
     - `projectRootFile` (str, default `config.flake-root.projectRootFile`)
     - `excludes` (list of str, default `["**/node_modules/**" "**/dist/**"]`)
     - `mdformat.validate` (bool, default `true`) - set to `false` to skip mdformat's validation step (`--no-validate`); useful for markdown files with extended/non-standard syntax (e.g., LaTeX).
-  - Enables formatters: Alejandra (Nix), Biome (JS/TS), HuJSON, latexindent, mdformat (MD), Ruff (check + format), Rustfmt, Shfmt (shell), ShellCheck (shell lint), Taplo (TOML), Yamlfmt.
+  - Enables formatters: Alejandra (Nix), Biome (JS/TS), HuJSON, latexindent, mdformat (MD), Ruff (check + format), Rustfmt, Shfmt (shell), Taplo (TOML), Yamlfmt.
 
 - just (`modules/flake-parts/just.nix`)
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ in {
     - `projectRootFile` (str, default `config.flake-root.projectRootFile`)
     - `excludes` (list of str, default `["**/node_modules/**" "**/dist/**"]`)
     - `mdformat.validate` (bool, default `true`) - set to `false` to skip mdformat's validation step (`--no-validate`); useful for markdown files with extended/non-standard syntax (e.g., LaTeX).
-  - Enables formatters: Alejandra (Nix), Biome (JS/TS), HuJSON, latexindent, mdformat (MD), Ruff (check + format), Rustfmt, Taplo (TOML), Yamlfmt.
+  - Enables formatters: Alejandra (Nix), Biome (JS/TS), HuJSON, latexindent, mdformat (MD), Ruff (check + format), Rustfmt, Shfmt (shell), ShellCheck (shell lint), Taplo (TOML), Yamlfmt.
 
 - just (`modules/flake-parts/just.nix`)
 

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -283,6 +283,65 @@ in {
         };
       };
 
+      # Shell script checks
+      shell = {
+        enable =
+          mkEnableOption "Shell script CI checks (shellcheck, actionlint, bashate)"
+          // {
+            default = false;
+            description = ''
+              Enable shell script CI checks. Disabled by default; opt in with
+              `jackpkgs.checks.shell.enable = true;`.
+            '';
+          };
+
+        shellcheck = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Enable ShellCheck linting of shell scripts";
+          };
+
+          extraArgs = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "Extra arguments to pass to shellcheck";
+          };
+        };
+
+        actionlint = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Enable actionlint for GitHub Actions workflows";
+          };
+
+          extraArgs = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "Extra arguments to pass to actionlint";
+          };
+        };
+
+        bashate = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Enable bashate style checks for shell scripts.
+              Disabled by default; opt in with
+              `jackpkgs.checks.shell.bashate.enable = true;`.
+            '';
+          };
+
+          extraArgs = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "Extra arguments to pass to bashate (e.g. [\"-E\", \"E006\"] to ignore rule E006)";
+          };
+        };
+      };
+
       # Future: golang, rust, etc. can be added here
     };
   };
@@ -742,6 +801,44 @@ in {
             '';
           };
         };
+
+      # ============================================================
+      # Shell Script Checks
+      # ============================================================
+
+      shellChecks = lib.optionalAttrs cfg.shell.enable (
+        lib.optionalAttrs cfg.shell.shellcheck.enable {
+          shellcheck = mkCheck {
+            name = "shellcheck";
+            buildInputs = [pkgs.shellcheck pkgs.fd];
+            checkCommands = ''
+              fd -t f --hidden -e sh -e bash -e .envrc -e .envrc. \
+                -X shellcheck ${lib.escapeShellArgs cfg.shell.shellcheck.extraArgs}
+            '';
+          };
+        }
+        // lib.optionalAttrs cfg.shell.actionlint.enable {
+          actionlint = mkCheck {
+            name = "actionlint";
+            buildInputs = [pkgs.actionlint pkgs.fd];
+            checkCommands = ''
+              test -d .github/workflows \
+                && fd -t f --hidden -g '*.{yml,yaml}' .github/workflows/ \
+                -X actionlint ${lib.escapeShellArgs cfg.shell.actionlint.extraArgs}
+            '';
+          };
+        }
+        // lib.optionalAttrs cfg.shell.bashate.enable {
+          bashate = mkCheck {
+            name = "bashate";
+            buildInputs = [pkgs.bashate pkgs.fd];
+            checkCommands = ''
+              fd -t f -e sh -e bash \
+                -X bashate ${lib.escapeShellArgs cfg.shell.bashate.extraArgs}
+            '';
+          };
+        }
+      );
     in
       # Merge all checks into the checks attribute
       lib.mkMerge [
@@ -750,6 +847,7 @@ in {
         {checks = vitestChecks;}
         {checks = biomeChecks;}
         {checks = beancountChecks;}
+        {checks = shellChecks;}
       ];
   };
 }

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -810,9 +810,10 @@ in {
         lib.optionalAttrs cfg.shell.shellcheck.enable {
           shellcheck = mkCheck {
             name = "shellcheck";
+            src = projectRoot;
             buildInputs = [pkgs.shellcheck pkgs.fd];
             checkCommands = ''
-              fd -t f --hidden -e sh -e bash -g .envrc \
+              fd -t f --hidden '.*\.sh$|.*\.bash$|^\.envrc$' \
                 -X shellcheck ${lib.escapeShellArgs cfg.shell.shellcheck.extraArgs}
             '';
           };
@@ -820,10 +821,11 @@ in {
         // lib.optionalAttrs cfg.shell.actionlint.enable {
           actionlint = mkCheck {
             name = "actionlint";
+            src = projectRoot;
             buildInputs = [pkgs.actionlint pkgs.fd];
             checkCommands = ''
               test -d .github/workflows \
-                && fd -t f --hidden -g '*.{yml,yaml}' .github/workflows/ \
+                && fd -t f --hidden -e yml -e yaml . .github/workflows/ \
                 -X actionlint ${lib.escapeShellArgs cfg.shell.actionlint.extraArgs}
             '';
           };
@@ -831,9 +833,10 @@ in {
         // lib.optionalAttrs cfg.shell.bashate.enable {
           bashate = mkCheck {
             name = "bashate";
+            src = projectRoot;
             buildInputs = [pkgs.bashate pkgs.fd];
             checkCommands = ''
-              fd -t f --hidden -e sh -e bash -g .envrc \
+              fd -t f --hidden '.*\.sh$|.*\.bash$|^\.envrc$' \
                 -X bashate ${lib.escapeShellArgs cfg.shell.bashate.extraArgs}
             '';
           };

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -806,7 +806,7 @@ in {
       # Shell Script Checks
       # ============================================================
 
-      shellChecks = lib.optionalAttrs cfg.shell.enable (
+      shellChecks = lib.optionalAttrs (cfg.enable && cfg.shell.enable) (
         lib.optionalAttrs cfg.shell.shellcheck.enable {
           shellcheck = mkCheck {
             name = "shellcheck";

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -812,7 +812,7 @@ in {
             name = "shellcheck";
             buildInputs = [pkgs.shellcheck pkgs.fd];
             checkCommands = ''
-              fd -t f --hidden -e sh -e bash -e .envrc -e .envrc. \
+              fd -t f --hidden -e sh -e bash -g .envrc \
                 -X shellcheck ${lib.escapeShellArgs cfg.shell.shellcheck.extraArgs}
             '';
           };
@@ -833,7 +833,7 @@ in {
             name = "bashate";
             buildInputs = [pkgs.bashate pkgs.fd];
             checkCommands = ''
-              fd -t f -e sh -e bash \
+              fd -t f --hidden -e sh -e bash -g .envrc \
                 -X bashate ${lib.escapeShellArgs cfg.shell.bashate.extraArgs}
             '';
           };

--- a/modules/flake-parts/fmt.nix
+++ b/modules/flake-parts/fmt.nix
@@ -149,6 +149,13 @@ in {
           enable = true;
           inherit excludes;
         };
+        # shell formatting via shfmt
+        programs.shfmt = {
+          enable = true;
+          inherit excludes;
+          indent_size = 2;
+          simplify = true;
+        };
         # toml
         programs.taplo = {
           enable = true;

--- a/modules/flake-parts/release-utils.sh
+++ b/modules/flake-parts/release-utils.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 fetch_latest() {
   local main_remote="$1"
   local main_branch="$2"
-  
+
   echo "📥 Fetching latest from $main_remote..." >&2
   git fetch --tags --prune "$main_remote"
   git fetch "$main_remote" "$main_branch":"refs/remotes/$main_remote/$main_branch"
-  
+
   if ! git rev-parse --verify --quiet "$main_remote/$main_branch" >/dev/null; then
     echo "❌ Unable to find $main_remote/$main_branch. Ensure the remote and branch exist." >&2
     exit 1
@@ -18,12 +18,12 @@ fetch_latest() {
 
 get_latest_tag() {
   local latest_tag=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-  
+
   if [ -z "$latest_tag" ]; then
     echo "❌ No semver tags found. Please create an initial tag like v0.1.0 first." >&2
     exit 1
   fi
-  
+
   echo "$latest_tag"
 }
 
@@ -31,14 +31,14 @@ create_and_push_tag() {
   local new_tag="$1"
   local main_remote="$2"
   local main_branch="$3"
-  
+
   local target_commit=$(git rev-parse "$main_remote/$main_branch")
   echo "🏷️  Creating tag $new_tag at $main_remote/$main_branch ($target_commit)..." >&2
   git tag -a "$new_tag" -m "Release $new_tag" "$target_commit"
-  
+
   echo "📤 Pushing tag to remote..." >&2
   git push origin "$new_tag"
-  
+
   echo "✅ Successfully created and pushed release tag: $new_tag" >&2
 }
 


### PR DESCRIPTION
## What

Add shell script linting/formatting to jackpkgs:

- **shfmt** — formatter via treefmt-nix (`programs.shfmt`), 2-space indent, simplify mode
- **shellcheck** — linter for shell scripts, off by default (`cfg.shell.shellcheck.enable`)
- **actionlint** — linter for GitHub Actions workflows, off by default (`cfg.shell.actionlint.enable`)
- **bashate** — style checker for bash scripts, off by default (`cfg.shell.bashate.enable`)

`cfg.shell.enable=false` by default. User must opt in. When shell checks are on, shellcheck and actionlint are enabled by default; bashate is off.

## Implementation

- treefmt for formatting only (shellcheck is a linter type, would break `nix fmt` if in treefmt)
- `mkCheck` pattern for all linters (in `checks.nix`, not treefmt)
- `fd -X` batches files into single invocation, handles empty results gracefully
- `fd --hidden` for `.envrc` and `.github/` directories
- `fd -e` for extension filtering (not `-l` which is `--list-details`)
- `test -d` guard for actionlint when `.github/workflows/` doesn't exist
- Brace expansion `*.{yml,yaml}` instead of multiple `-g` flags
- `shellChecks` gated on `cfg.enable && cfg.shell.enable` (consistent with other check families)

## Testing

```
nix flake check --no-build  # ✅
nix fmt                     # ✅
```

Fixes #240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new formatting and opt-in CI checks without changing existing check behavior by default; primary risk is new lint rules failing in repos that enable `jackpkgs.checks.shell.enable`.
> 
> **Overview**
> Adds shell support to the flake-parts tooling: `treefmt` now formats shell scripts via `shfmt` (2-space indent, simplify mode).
> 
> Introduces an **opt-in** `jackpkgs.checks.shell` check family that can run `shellcheck`, `actionlint`, and (separately) `bashate`, and wires these into the aggregated `checks` output when enabled. Documentation is updated to mention `Shfmt`, and `release-utils.sh` is reformatted (no functional changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751ab15ddefe1c6368d867d84280c577d6046ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->