### PR TITLE
Include pnpm in ci-pulumi for Node projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
 
   - Provides Pulumi CLI in a devShell fragment: `config.jackpkgs.outputs.pulumiDevShell`.
   - Provides generated justfile fragment: `config.jackpkgs.outputs.pulumiJustfile` with `preview`/`deploy` recipes.
-  - Provides CI devshell: `devShells.ci-pulumi` with minimal dependencies for CI environments.
+  - Provides CI devshell: `devShells.ci-pulumi` with minimal dependencies for CI environments. When `jackpkgs.nodejs.enable` is true, this shell also includes the configured `pnpmPackage` so Pulumi CI can install Node.js dependencies.
   - When enabled, both Pulumi shells export `PULUMI_OPTION_NON_INTERACTIVE=true`, `PULUMI_OPTION_COLOR=never`, and `PULUMI_OPTION_SUPPRESS_PROGRESS=true` for plain, non-interactive CLI output, plus `NODE_OPTIONS=--async-context-frame` for better Node/Pulumi async stack traces.
   - Options under `jackpkgs.pulumi`:
     - `enable` (bool, default `true`)

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -9,11 +9,11 @@ pkgs.makeSetupHook {inherit name;} (
   pkgs.writeText "${name}.sh" (
     lib.concatStringsSep "\n" (
       lib.mapAttrsToList
-        (var: value:
-          if builtins.match "[a-zA-Z_][a-zA-Z0-9_]*" var == null
-          then throw "mkShellEnvHook: invalid shell variable name '${var}'"
-          else "export ${var}=${lib.escapeShellArg (toString value)}")
-        (lib.filterAttrs (_: v: v != null) env)
+      (var: value:
+        if builtins.match "[a-zA-Z_][a-zA-Z0-9_]*" var == null
+        then throw "mkShellEnvHook: invalid shell variable name '${var}'"
+        else "export ${var}=${lib.escapeShellArg (toString value)}")
+      (lib.filterAttrs (_: v: v != null) env)
     )
   )
 )

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -100,27 +100,26 @@ in {
           ++ lib.optional cfg.welcome.showJustHint ''echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
         );
     in {
-      jackpkgs.outputs.devShell = pkgs.mkShell (
-        {
-          inputsFrom =
-            [
-              config.just-flake.outputs.devShell
-              config.flake-root.devShell
-              config.pre-commit.devShell
-              config.treefmt.build.devShell
-            ]
-            ++ sysCfg.inputsFrom;
-          packages = sysCfg.packages
-            ++ lib.optional (!cfg.direnv.showEnvDiff) (
-              mkShellEnvHook {
-                name = "jackpkgs-direnv-log-format-hook";
-                env = {DIRENV_LOG_FORMAT = "";};
-              }
-            );
+      jackpkgs.outputs.devShell = pkgs.mkShell {
+        inputsFrom =
+          [
+            config.just-flake.outputs.devShell
+            config.flake-root.devShell
+            config.pre-commit.devShell
+            config.treefmt.build.devShell
+          ]
+          ++ sysCfg.inputsFrom;
+        packages =
+          sysCfg.packages
+          ++ lib.optional (!cfg.direnv.showEnvDiff) (
+            mkShellEnvHook {
+              name = "jackpkgs-direnv-log-format-hook";
+              env = {DIRENV_LOG_FORMAT = "";};
+            }
+          );
 
-          shellHook = lib.concatStringsSep "\n" shellHookParts;
-        }
-      );
+        shellHook = lib.concatStringsSep "\n" shellHookParts;
+      };
     };
   };
 }

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -84,6 +84,7 @@ in {
     perSystem = mkDeferredModuleOption ({
       config,
       lib,
+      options,
       pkgs,
       ...
     }: {
@@ -95,21 +96,37 @@ in {
 
       options.jackpkgs.pulumi.ci.packages = mkOption {
         type = with types; listOf package;
-        default = with config.jackpkgs.pkgs; [
-          pulumi-bin
-          nodejs
-          jq
-          (google-cloud-sdk.withExtraComponents [google-cloud-sdk.components.gke-gcloud-auth-plugin])
-        ];
+        default = let
+          isNodeEnabled =
+            lib.hasAttrByPath ["jackpkgs" "outputs" "nodejsDevShell"] options
+            && config.jackpkgs.outputs.nodejsDevShell != null;
+          nodejsPackage =
+            if isNodeEnabled
+            then config.jackpkgs.nodejs.package
+            else config.jackpkgs.pkgs.nodejs;
+          pnpmPackages = lib.optional isNodeEnabled config.jackpkgs.nodejs.pnpmPackage;
+        in
+          with config.jackpkgs.pkgs;
+            [
+              pulumi-bin
+              nodejsPackage
+              jq
+              (google-cloud-sdk.withExtraComponents [google-cloud-sdk.components.gke-gcloud-auth-plugin])
+            ]
+            ++ pnpmPackages;
         defaultText = lib.literalExpression ''
           with config.jackpkgs.pkgs; [
             pulumi-bin
             nodejs
             jq
             (google-cloud-sdk.withExtraComponents [google-cloud-sdk.components.gke-gcloud-auth-plugin])
-          ]
+          ] ++ lib.optional config.jackpkgs.nodejs.enable config.jackpkgs.nodejs.pnpmPackage
         '';
-        description = "Packages included in the ci-pulumi devshell";
+        description = ''
+          Packages included in the ci-pulumi devshell. When the Node.js module
+          is enabled, this includes its configured pnpm package so reusable
+          Pulumi CI workflows can run `pnpm install` inside `.#ci-pulumi`.
+        '';
       };
 
       options.jackpkgs.outputs.pulumiJustfile = mkOption {
@@ -138,11 +155,12 @@ in {
         # is selected without a gcp.profile. Without this, the devShell would
         # silently skip GOOGLE_APPLICATION_CREDENTIALS.
         adcProfileRequired =
-          cfg.ci.authMode == "application-default-credentials"
+          cfg.ci.authMode
+          == "application-default-credentials"
           && gcpCfg.profile == null;
         assertAdcProfile =
           lib.asserts.assertMsg (!adcProfileRequired)
-            "jackpkgs.pulumi.ci.authMode 'application-default-credentials' requires jackpkgs.gcp.profile to be set";
+          "jackpkgs.pulumi.ci.authMode 'application-default-credentials' requires jackpkgs.gcp.profile to be set";
 
         # Shared base env vars present in every Pulumi shell.
         pulumiBaseEnv = {
@@ -163,10 +181,9 @@ in {
         # NOTE: This attrset is used only for the CI JSON env check (checks.pulumi-ci-env).
         # The actual GOOGLE_APPLICATION_CREDENTIALS export is done via shellHook
         # (adcShellHook) because the path contains $HOME which requires runtime expansion.
-        profileAdcPath =
-          lib.optionalAttrs (gcpCfg.profile != null) {
-            GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json";
-          };
+        profileAdcPath = lib.optionalAttrs (gcpCfg.profile != null) {
+          GOOGLE_APPLICATION_CREDENTIALS = "$HOME/.config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json";
+        };
 
         ciPulumiEnv =
           pulumiBaseEnv

--- a/tests/pulumi.nix
+++ b/tests/pulumi.nix
@@ -28,8 +28,14 @@
     secretsProvider ? "awskms://alias/pulumi",
     defaultStack ? "dev",
     stacks ? [],
+    nodejsEnable ? false,
   }: {
     _module.check = false;
+    jackpkgs.nodejs = lib.mkIf nodejsEnable {
+      enable = true;
+      pnpmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      projectRoot = ../.;
+    };
     jackpkgs.pulumi = {
       enable = true;
       inherit backendUrl defaultStack secretsProvider stacks;
@@ -67,6 +73,13 @@ in {
     perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
   in {
     expr = hasPulumiEnvSetupHook "jackpkgs-pulumi-env-hook" perSystemCfg.jackpkgs.outputs.devShell;
+    expected = true;
+  };
+
+  testCiPulumiPackagesIncludePnpmWhenNodejsEnabled = let
+    perSystemCfg = getPerSystemCfg [(mkConfigModule {nodejsEnable = true;})];
+  in {
+    expr = builtins.elem perSystemCfg.jackpkgs.nodejs.pnpmPackage perSystemCfg.jackpkgs.pulumi.ci.packages;
     expected = true;
   };
 


### PR DESCRIPTION
## Summary

- include the configured `jackpkgs.nodejs.pnpmPackage` in `devShells.ci-pulumi` when the Node.js module is enabled
- keep the non-Node Pulumi CI shell minimal when `jackpkgs.nodejs.enable` is false
- add a nix-unit regression test for the Node.js-enabled ci-pulumi package set
- update README docs for the ci-pulumi shell contract

## Validation

- `nix build .#checks.aarch64-darwin.nix-unit --show-trace`
- `nix fmt -- --fail-on-change`
- `nix flake check --no-build`

Context: toolbox issue jmmaloney4/toolbox#158 found that reusable Pulumi CI runs `pnpm install` inside the caller repo's `.#ci-pulumi` shell, but jackpkgs' generated ci-pulumi shell only provided Node.js, not pnpm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust devShell package defaults and add a regression test/docs; main impact is ensuring `devShells.ci-pulumi` includes `pnpm` for Node-based Pulumi CI runs.
> 
> **Overview**
> Updates the Pulumi CI devshell contract so `devShells.ci-pulumi` conditionally includes the configured `jackpkgs.nodejs.pnpmPackage` (and uses the configured Node package) when the Node.js module is enabled, while keeping the non-Node shell minimal.
> 
> Adds a nix-unit regression test covering the Node-enabled package set, and updates README docs accordingly; remaining diffs are minor Nix formatting/structural cleanups in `devshell.nix` and `shell-env-hook.nix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d13d52c8880d4a3657076708377fb804b42c361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->