### PR TITLE
fix(pulumi): set NODE_OPTIONS=--async-context-frame in pulumiBaseEnv

### DIFF
--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -141,6 +141,10 @@ in {
           PULUMI_OPTION_NON_INTERACTIVE = "true";
           PULUMI_OPTION_COLOR = "never";
           PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
+          # Enable async stack traces in Node.js for better debugging of unhandled
+          # promise rejections (e.g. from @pulumi/pulumi). Without this, async stack
+          # frames are absent from Error.stack, making unhandled rejections hard to trace.
+          NODE_OPTIONS = "--async-context-frame";
         };
 
         # ADC file path for the active gcp.profile (null-safe: only used when profile != null).


### PR DESCRIPTION
## Problem

Node.js 24+ drops async stack frames from `Error.stack` by default. When `@pulumi/pulumi`'s language host runs a Pulumi program via `node`, unhandled promise rejections that contain non-Error values (e.g. a `{}` null-prototype object) produce the cryptic error:

```
TypeError: Cannot convert object to primitive value
    at process.uncaughtHandler (@pulumi/cmd/run/index.ts:49)
```

This masks the real error because the uncaught handler tries `"" + err` on an object with no primitive value. Without `--async-context-frame`, `Error().stack` captures zero async frames, making the origin of the rejection impossible to trace.

## Fix

Add `NODE_OPTIONS=--async-context-frame` to `pulumiBaseEnv`, which is included in every Pulumi devshell (`pulumiDevShell`, `ci-pulumi`, and the composed `jackpkgs.shell` via `inputsFrom`).

## Changed files

- `modules/flake-parts/pulumi.nix`: +4 lines in `pulumiBaseEnv`

## Testing

After this change, `pulumi preview` in a Pulumi project using jackpkgs will produce full async stack traces in unhandled rejection output, enabling diagnosis of what code is producing the `{}` rejection in `deploy/pipelines`.

## Checklist

- [x] `nix flake check` passes (aarch64-darwin; x86_64-linux via CI)
- [x] CI passes on x86_64-linux (treefmt, nix-unit all green; openchamber building)
- [wip] `checks.x86_64-linux.pre-commit` — pre-existing failure on main (run #897 on `68fbeb4` also shows this failure); not related to this PR's changes
