### PR TITLE
fix(devshell): propagate Pulumi env through composed shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,14 +277,14 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
 
   - Produces a composable dev shell output: `config.jackpkgs.outputs.devShell`.
   - The shell aggregates dev environments from `just-flake`, `flake-root`, `pre-commit`, and `treefmt`.
-  - When `jackpkgs.pulumi.enable` is true, the composed dev shell exports `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER`, and `PULUMI_IGNORE_AMBIENT_PLUGINS=1`.
+  - When `jackpkgs.pulumi.enable` is true, the composed dev shell exports the shared Pulumi environment: `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER`, `PULUMI_IGNORE_AMBIENT_PLUGINS=1`, Pulumi non-interactive output defaults, and `NODE_OPTIONS=--async-context-frame`.
 
 - pulumi (`modules/flake-parts/pulumi.nix`)
 
   - Provides Pulumi CLI in a devShell fragment: `config.jackpkgs.outputs.pulumiDevShell`.
   - Provides generated justfile fragment: `config.jackpkgs.outputs.pulumiJustfile` with `preview`/`deploy` recipes.
   - Provides CI devshell: `devShells.ci-pulumi` with minimal dependencies for CI environments.
-  - When enabled, both Pulumi shells export `PULUMI_OPTION_NON_INTERACTIVE=true`, `PULUMI_OPTION_COLOR=never`, and `PULUMI_OPTION_SUPPRESS_PROGRESS=true` for plain, non-interactive CLI output.
+  - When enabled, both Pulumi shells export `PULUMI_OPTION_NON_INTERACTIVE=true`, `PULUMI_OPTION_COLOR=never`, and `PULUMI_OPTION_SUPPRESS_PROGRESS=true` for plain, non-interactive CLI output, plus `NODE_OPTIONS=--async-context-frame` for better Node/Pulumi async stack traces.
   - Options under `jackpkgs.pulumi`:
     - `enable` (bool, default `true`)
     - `backendUrl` (str, required) - Pulumi backend URL

--- a/docs/internal/designs/034-devshell-composition-contract.md
+++ b/docs/internal/designs/034-devshell-composition-contract.md
@@ -62,14 +62,14 @@ for development-shell fragments, but narrow its contract:
    hooks.
 2. `inputsFrom` MUST NOT be relied on to propagate `env` attributes or upstream
    `shellHook` behavior into a downstream shell.
-3. Any environment variable that must survive shell composition MUST be carried by
-   a setup hook package included in the upstream shell's inputs.
-4. Directly-entered shells SHOULD still set their own `env` attrs and/or
-   `shellHook` exports when useful for direct evaluation, introspection, or human
-   readability.
+3. Any environment variable that must be provided by a jackpkgs shell MUST be
+   carried by a setup hook package included in that shell's inputs.
+4. Modules SHOULD NOT duplicate durable environment exports through `env` attrs or
+   `shellHook`. Those paths are easy to mistake for the composition contract and
+   can drift from the setup hook.
 5. `jackpkgs` SHOULD document reusable shell outputs as "shell fragments" whose
-   stable cross-composition interface is build inputs plus setup hooks, not the
-   whole `mkShell` attribute set.
+   stable interface is build inputs plus setup hooks, not the whole `mkShell`
+   attribute set.
 
 We will not introduce a public custom shell-composition function at this time.
 Instead, each module that needs environment propagation should expose it through a
@@ -92,12 +92,12 @@ normal setup hook package, and include that package in the relevant dev shell.
 **Trade-offs:**
 
 - Setup hooks are less obvious than plain `env = { ...; }` attributes.
-- Variables now exist in more than one representation (`env` attrs for direct
-  shell metadata and setup hooks for composed-shell behavior), so module authors
-  must avoid drift by deriving both from the same attrset.
-- The final composed shell may not expose the variable as an evaluable derivation
-  attribute even though it is present in the interactive environment; validation
-  must include actual `nix develop` checks for important paths.
+- The final shell does not expose these variables as evaluable derivation
+  attributes even though they are present in the interactive environment;
+  validation must include setup-hook presence checks and/or actual `nix develop`
+  checks for important paths.
+- Nix-level tests should avoid asserting `drv.VAR`; the source of truth is the
+  setup hook included in the shell inputs.
 
 **Risks and Mitigations:**
 
@@ -118,7 +118,7 @@ normal setup hook package, and include that package in the relevant dev shell.
 
 ## Alternatives Considered
 
-### A: Continue with `env = { ...; }` only
+### A: Use `env = { ...; }`
 
 Pros: simple Nix syntax; easy to inspect with `nix eval`; works for direct
 `mkShell` entry in many cases.
@@ -126,7 +126,8 @@ Pros: simple Nix syntax; easy to inspect with `nix eval`; works for direct
 Cons: does not reliably propagate through downstream `inputsFrom` composition;
 this is the root cause of the Pulumi and `NODE_OPTIONS` regressions.
 
-Rejected because it does not satisfy the consumer composition requirement.
+Rejected because it does not satisfy the consumer composition requirement and
+creates a misleading second path for environment propagation.
 
 ### B: Put all critical variables only in `shellHook`
 
@@ -137,7 +138,8 @@ Cons: upstream `shellHook` behavior is not a reliable contract for downstream
 shells that compose with `inputsFrom`. It also mixes durable environment state
 with human-facing shell-entry behavior.
 
-Rejected as insufficient for wrapped consumer shells.
+Rejected because it is insufficient for wrapped consumer shells and creates a
+misleading second path for environment propagation.
 
 ### C: Setup-hook packages carried through `inputsFrom`
 

--- a/docs/internal/designs/034-devshell-composition-contract.md
+++ b/docs/internal/designs/034-devshell-composition-contract.md
@@ -1,0 +1,236 @@
+---
+id: ADR-034
+title: Devshell Composition Contract
+status: proposed
+date: 2026-04-27
+---
+
+# ADR-034: Devshell Composition Contract
+
+## Status
+
+Proposed
+
+## Context
+
+`jackpkgs` exposes several reusable development-shell fragments through
+flake-parts outputs, including:
+
+- `config.jackpkgs.outputs.devShell`
+- `config.jackpkgs.outputs.pulumiDevShell`
+- `config.jackpkgs.outputs.pythonEditableHook`
+- `config.jackpkgs.outputs.nodejsDevShell`
+
+Consumers commonly compose these fragments into their final project shell with
+`pkgs.mkShell { inputsFrom = [ ... ]; }`. This is convenient for packages and
+setup hooks, but recent Pulumi environment fixes exposed a boundary problem:
+variables declared as `env = { ...; }` on an upstream shell do not reliably appear
+in the final consumer shell when that upstream shell is included via
+`inputsFrom`.
+
+The affected variables included the Pulumi non-interactive output defaults from
+PR #205:
+
+- `PULUMI_OPTION_NON_INTERACTIVE=true`
+- `PULUMI_OPTION_COLOR=never`
+- `PULUMI_OPTION_SUPPRESS_PROGRESS=true`
+
+and the Node/Pulumi debugging flag from PR #242:
+
+- `NODE_OPTIONS=--async-context-frame`
+
+The same class of problem can affect any variable that is only represented as a
+shell derivation attribute, rather than carried through the build-input/setup-hook
+composition path.
+
+Key constraints:
+
+- Consumers should be able to compose jackpkgs-provided shell functionality
+  without copying package lists or environment details into their own flakes.
+- Environment behavior should be explicit and testable.
+- Existing consumers already use `inputsFrom`; changing the public composition
+  model should be avoided unless there is a clear correctness or ergonomics win.
+- `jackpkgs` should not require every consumer to call a custom helper just to get
+  the standard module-provided development environment.
+
+## Decision
+
+Continue using `mkShell` plus `inputsFrom` as the public composition mechanism
+for development-shell fragments, but narrow its contract:
+
+1. `inputsFrom` is appropriate for propagating packages, build inputs, and setup
+   hooks.
+2. `inputsFrom` MUST NOT be relied on to propagate `env` attributes or upstream
+   `shellHook` behavior into a downstream shell.
+3. Any environment variable that must survive shell composition MUST be carried by
+   a setup hook package included in the upstream shell's inputs.
+4. Directly-entered shells SHOULD still set their own `env` attrs and/or
+   `shellHook` exports when useful for direct evaluation, introspection, or human
+   readability.
+5. `jackpkgs` SHOULD document reusable shell outputs as "shell fragments" whose
+   stable cross-composition interface is build inputs plus setup hooks, not the
+   whole `mkShell` attribute set.
+
+We will not introduce a public custom shell-composition function at this time.
+Instead, each module that needs environment propagation should expose it through a
+normal setup hook package, and include that package in the relevant dev shell.
+
+## Consequences
+
+**Benefits:**
+
+- Keeps the consumer-facing API aligned with normal nixpkgs/flake practice:
+  compose shell fragments via `inputsFrom`.
+- Fixes the concrete Pulumi variables for consumers that wrap
+  `config.jackpkgs.outputs.devShell` in their own project shell.
+- Avoids a new jackpkgs-specific shell DSL that consumers would need to learn.
+- Makes environment propagation testable by checking for setup-hook inputs and by
+  entering a downstream shell with `nix develop`.
+- Preserves direct-shell behavior for users who enter `pulumiDevShell` or
+  `jackpkgs.outputs.devShell` directly.
+
+**Trade-offs:**
+
+- Setup hooks are less obvious than plain `env = { ...; }` attributes.
+- Variables now exist in more than one representation (`env` attrs for direct
+  shell metadata and setup hooks for composed-shell behavior), so module authors
+  must avoid drift by deriving both from the same attrset.
+- The final composed shell may not expose the variable as an evaluable derivation
+  attribute even though it is present in the interactive environment; validation
+  must include actual `nix develop` checks for important paths.
+
+**Risks and Mitigations:**
+
+- *Risk:* Future modules add `env = { ...; }` to shell fragments and assume it
+  propagates through `inputsFrom`.
+  *Mitigation:* Document this ADR, keep tests for composed-shell propagation, and
+  prefer helper patterns that derive setup hooks from an env attrset.
+
+- *Risk:* Setup-hook ordering surprises if multiple fragments export the same
+  variable.
+  *Mitigation:* Treat duplicate environment ownership as a design smell. If a
+  variable is intentionally overrideable, document the precedence and use normal
+  shell semantics (`export VAR="${VAR:-default}"`) where appropriate.
+
+- *Risk:* Setup hooks may run in contexts beyond interactive shell entry.
+  *Mitigation:* Keep setup hooks limited to deterministic environment exports and
+  avoid expensive side effects, prompts, filesystem writes, or network access.
+
+## Alternatives Considered
+
+### A: Continue with `env = { ...; }` only
+
+Pros: simple Nix syntax; easy to inspect with `nix eval`; works for direct
+`mkShell` entry in many cases.
+
+Cons: does not reliably propagate through downstream `inputsFrom` composition;
+this is the root cause of the Pulumi and `NODE_OPTIONS` regressions.
+
+Rejected because it does not satisfy the consumer composition requirement.
+
+### B: Put all critical variables only in `shellHook`
+
+Pros: visible in `nix eval ...shellHook`; familiar to shell users; works when
+entering the shell directly.
+
+Cons: upstream `shellHook` behavior is not a reliable contract for downstream
+shells that compose with `inputsFrom`. It also mixes durable environment state
+with human-facing shell-entry behavior.
+
+Rejected as insufficient for wrapped consumer shells.
+
+### C: Setup-hook packages carried through `inputsFrom`
+
+Pros: uses the part of shell composition that is meant to cross derivation
+boundaries: build inputs and setup hooks. It works for wrapped shells and can be
+implemented without changing consumer flakes.
+
+Cons: less obvious than `env`; requires tests that distinguish direct shell attrs
+from final interactive environment.
+
+Chosen because it preserves the existing public composition style while making
+environment propagation reliable.
+
+### D: Expose a custom `jackpkgs.lib.mkDevShell` composition function
+
+Pros: could centralize package, env, and shellHook merging in one helper; could
+provide a richer typed interface than raw `mkShell`.
+
+Cons: every consumer would need to opt into a jackpkgs-specific wrapper. It would
+still need to interoperate with third-party shell fragments that are already
+`mkShell` derivations. It risks becoming a parallel shell framework rather than a
+small reusable flake module library.
+
+Not chosen now. A custom helper may be reconsidered if multiple modules need
+structured merging that setup hooks cannot express, but the current problem is
+solved by setup hooks with no consumer migration.
+
+### E: Expose attrset fragments instead of shell derivations
+
+Example shape:
+
+```nix
+jackpkgs.outputs.shellFragments.pulumi = {
+  packages = [ ... ];
+  env = { ...; };
+  shellHook = ''...'';
+};
+```
+
+Pros: explicit and mergeable; consumers or helper functions can combine fragments
+without losing attr-level information.
+
+Cons: changes the consumer contract, duplicates what `mkShell` already models for
+packages, and requires migration or dual outputs. It also does not solve
+composition with third-party `mkShell` fragments unless converted back into setup
+hooks.
+
+Not chosen for the current fix, but this is a plausible future direction if
+jackpkgs needs a first-class shell-fragment API.
+
+## Implementation Plan
+
+1. Derive shared Pulumi environment exports from a single `pulumiEnv` attrset in
+   `modules/flake-parts/devshell.nix`.
+2. Keep `env = pulumiEnv` on `config.jackpkgs.outputs.devShell` for direct-shell
+   metadata and Nix-level tests.
+3. Export the same variables in `shellHook` for direct shell entry.
+4. Create a `pkgs.makeSetupHook` package that exports the same variables and add
+   it to `config.jackpkgs.outputs.devShell` packages when Pulumi is enabled.
+5. Add tests that verify the composed dev shell includes the setup hook and that
+   the expected exports are present in the direct shell hook.
+6. Validate with a real downstream composition using `nix develop --override-input jackpkgs <local-jackpkgs-checkout>` from a consumer repository.
+
+## Appendix: Code Changes in PR #243
+
+PR #243 implements this decision by updating:
+
+- `modules/flake-parts/devshell.nix`
+
+  - Adds the PR #205 Pulumi option variables to the shared `pulumiEnv` attrset.
+  - Keeps `NODE_OPTIONS=--async-context-frame` in that same attrset.
+  - Builds export statements from the attrset with `lib.mapAttrsToList`.
+  - Adds `jackpkgs-pulumi-env-hook` via `pkgs.makeSetupHook`.
+  - Includes that hook in the dev shell packages when Pulumi is enabled.
+
+- `tests/pulumi.nix`
+
+  - Adds `NODE_OPTIONS` to expected Pulumi shell env.
+  - Adds a composed-shell test that requires both shellHook exports and the setup
+    hook package.
+
+- `README.md`
+
+  - Documents the shared Pulumi environment exported by the composed shell.
+
+## Related
+
+- PR #205: Pulumi non-interactive CLI defaults
+- PR #242: `NODE_OPTIONS=--async-context-frame` for Pulumi/Node async stack traces
+- PR #243: Propagate Pulumi env through composed shells
+- `modules/flake-parts/devshell.nix`
+- `modules/flake-parts/pulumi.nix`
+
+______________________________________________________________________
+
+*Author: Jack Maloney — 2026-04-27*

--- a/docs/internal/designs/034-devshell-composition-contract.md
+++ b/docs/internal/designs/034-devshell-composition-contract.md
@@ -192,16 +192,21 @@ jackpkgs needs a first-class shell-fragment API.
 
 ## Implementation Plan
 
-1. Derive shared Pulumi environment exports from a single `pulumiEnv` attrset in
-   `modules/flake-parts/devshell.nix`.
-2. Keep `env = pulumiEnv` on `config.jackpkgs.outputs.devShell` for direct-shell
-   metadata and Nix-level tests.
-3. Export the same variables in `shellHook` for direct shell entry.
-4. Create a `pkgs.makeSetupHook` package that exports the same variables and add
-   it to `config.jackpkgs.outputs.devShell` packages when Pulumi is enabled.
-5. Add tests that verify the composed dev shell includes the setup hook and that
-   the expected exports are present in the direct shell hook.
-6. Validate with a real downstream composition using `nix develop --override-input jackpkgs <local-jackpkgs-checkout>` from a consumer repository.
+1. Create a `pkgs.makeSetupHook` package (via `lib/shell-env-hook.nix`) that
+   exports Pulumi environment variables and include it in
+   `config.jackpkgs.outputs.pulumiDevShell` packages.
+2. The pulumi module adds `pulumiDevShell` to `jackpkgs.shell.inputsFrom`, so
+   the composed `jackpkgs.outputs.devShell` receives the setup hook through
+   normal `inputsFrom` propagation — no duplicate env or hook in devshell.nix.
+3. `shellHook` in `devshell.nix` is reserved for non-env side effects (welcome
+   messages, gcloud profile setup). Durable env vars travel only through setup
+   hooks.
+4. Add tests that verify the setup hook package is present in both
+   `pulumiDevShell` and the composed devShell, and that downstream composition
+   via `nix develop --override-input` exposes the expected variables.
+5. Validate with a real downstream composition using
+   `nix develop --override-input jackpkgs <local-jackpkgs-checkout>` from a
+   consumer repository.
 
 ## Appendix: Code Changes in PR #243
 
@@ -209,11 +214,12 @@ PR #243 implements this decision by updating:
 
 - `modules/flake-parts/devshell.nix`
 
-  - Adds the PR #205 Pulumi option variables to the shared `pulumiEnv` attrset.
-  - Keeps `NODE_OPTIONS=--async-context-frame` in that same attrset.
-  - Builds export statements from the attrset with `lib.mapAttrsToList`.
-  - Adds `jackpkgs-pulumi-env-hook` via `pkgs.makeSetupHook`.
-  - Includes that hook in the dev shell packages when Pulumi is enabled.
+  - Removes the duplicate `pulumiEnv` attrset — environment is defined once in
+    `modules/flake-parts/pulumi.nix` as `pulumiBaseEnv`.
+  - Pulumi setup hook propagates through `inputsFrom` from `pulumiDevShell`;
+    devshell.nix no longer builds its own hook.
+  - `shellHook` reserved for non-env side effects only (welcome messages, gcloud
+    profile setup).
 
 - `tests/pulumi.nix`
 

--- a/docs/internal/designs/034-devshell-composition-contract.md
+++ b/docs/internal/designs/034-devshell-composition-contract.md
@@ -193,18 +193,29 @@ jackpkgs needs a first-class shell-fragment API.
 ## Implementation Plan
 
 1. Create a `pkgs.makeSetupHook` package (via `lib/shell-env-hook.nix`) that
-   exports Pulumi environment variables and include it in
+   exports **literal (compile-time) environment variables** and include it in
    `config.jackpkgs.outputs.pulumiDevShell` packages.
+   - The helper uses `lib.escapeShellArg` (single-quoting) for safe, injection-
+     resistant exports. It also filters out `null` values to match `mkShell`
+     behavior.
 2. The pulumi module adds `pulumiDevShell` to `jackpkgs.shell.inputsFrom`, so
    the composed `jackpkgs.outputs.devShell` receives the setup hook through
    normal `inputsFrom` propagation — no duplicate env or hook in devshell.nix.
-3. `shellHook` in `devshell.nix` is reserved for non-env side effects (welcome
-   messages, gcloud profile setup). Durable env vars travel only through setup
-   hooks.
-4. Add tests that verify the setup hook package is present in both
+3. **Design split for runtime-expanded values:** variables that reference
+   `$HOME` or require shell expansion (e.g. `GOOGLE_APPLICATION_CREDENTIALS`
+   with a profile-dependent path) are exported via `shellHook`, not setup hooks.
+   This avoids the injection risk of double-quoting in the generic helper while
+   preserving runtime expansion semantics.
+   - `devshell.nix` `shellHookParts`: `CLOUDSDK_CONFIG`, `GOOGLE_APPLICATION_CREDENTIALS`
+     (shared non-Pulumi path), `mkdir -p`.
+   - `pulumi.nix` `adcShellHook`: `GOOGLE_APPLICATION_CREDENTIALS` with profile-
+     specific `$HOME` path (Pulumi-specific override).
+4. `shellHook` in `devshell.nix` also handles non-env side effects (welcome
+   messages, gcloud profile setup).
+5. Add tests that verify the setup hook package is present in both
    `pulumiDevShell` and the composed devShell, and that downstream composition
    via `nix develop --override-input` exposes the expected variables.
-5. Validate with a real downstream composition using
+6. Validate with a real downstream composition using
    `nix develop --override-input jackpkgs <local-jackpkgs-checkout>` from a
    consumer repository.
 
@@ -212,18 +223,37 @@ jackpkgs needs a first-class shell-fragment API.
 
 PR #243 implements this decision by updating:
 
+- `lib/shell-env-hook.nix`
+
+  - New shared helper: converts an env attrset to a `makeSetupHook` package.
+  - Uses `lib.escapeShellArg` (single-quoting) for injection-resistant exports.
+  - Filters `null` values to match `mkShell` behavior.
+
 - `modules/flake-parts/devshell.nix`
 
   - Removes the duplicate `pulumiEnv` attrset — environment is defined once in
     `modules/flake-parts/pulumi.nix` as `pulumiBaseEnv`.
   - Pulumi setup hook propagates through `inputsFrom` from `pulumiDevShell`;
     devshell.nix no longer builds its own hook.
-  - `shellHook` reserved for non-env side effects only (welcome messages, gcloud
-    profile setup).
+  - `shellHook` handles runtime-expanded env vars (`CLOUDSDK_CONFIG`,
+    `GOOGLE_APPLICATION_CREDENTIALS`) and non-env side effects (welcome messages,
+    gcloud profile setup).
+
+- `modules/flake-parts/pulumi.nix`
+
+  - Single `pulumiEnvHook` setup hook carries literal Pulumi env vars
+    (`PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER`, `PULUMI_OPTION_*`,
+    `NODE_OPTIONS`). Used by both `pulumiDevShell` and `ci-pulumi`.
+  - `adcShellHook` exports `GOOGLE_APPLICATION_CREDENTIALS` via `shellHook` for
+    runtime `$HOME` expansion (profile-specific path, escaped with
+    `lib.escapeShellArg`).
+  - Removed separate `ciPulumiEnvHook` (was identical to `pulumiEnvHook`).
 
 - `tests/pulumi.nix`
 
   - Adds `NODE_OPTIONS` to expected Pulumi shell env.
+  - Tests assert `jackpkgs-pulumi-env-hook` in both `pulumiDevShell` and
+    `ci-pulumi` (consolidated single hook).
   - Adds a composed-shell test that requires both shellHook exports and the setup
     hook package.
 

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -8,7 +8,15 @@
 pkgs.makeSetupHook {inherit name;} (
   pkgs.writeText "${name}.sh" (
     lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg (toString value)}") env
+      lib.mapAttrsToList (
+        var: value:
+        # Use double-quoting so shell variables like $HOME expand at runtime.
+        # Escape internal double-quotes and backslashes in the Nix value.
+        let
+          escaped = lib.strings.escape ["\\" "\""] (toString value);
+        in "export ${var}=\"${escaped}\""
+      )
+      env
     )
   )
 )

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -8,7 +8,7 @@
 pkgs.makeSetupHook {inherit name;} (
   pkgs.writeText "${name}.sh" (
     lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg (toString value)}") env
+      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg (toString value)}") (lib.filterAttrs (_: v: v != null) env)
     )
   )
 )

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  pkgs,
+}: {
+  name,
+  env,
+}:
+pkgs.makeSetupHook {inherit name;} (
+  pkgs.writeText "${name}.sh" (
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg value}") env
+    )
+  )
+)

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -8,7 +8,7 @@
 pkgs.makeSetupHook {inherit name;} (
   pkgs.writeText "${name}.sh" (
     lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg value}") env
+      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg (toString value)}") env
     )
   )
 )

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -8,15 +8,7 @@
 pkgs.makeSetupHook {inherit name;} (
   pkgs.writeText "${name}.sh" (
     lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (
-        var: value:
-        # Use double-quoting so shell variables like $HOME expand at runtime.
-        # Escape internal double-quotes and backslashes in the Nix value.
-        let
-          escaped = lib.strings.escape ["\\" "\""] (toString value);
-        in "export ${var}=\"${escaped}\""
-      )
-      env
+      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg (toString value)}") env
     )
   )
 )

--- a/lib/shell-env-hook.nix
+++ b/lib/shell-env-hook.nix
@@ -8,7 +8,12 @@
 pkgs.makeSetupHook {inherit name;} (
   pkgs.writeText "${name}.sh" (
     lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (var: value: "export ${var}=${lib.escapeShellArg (toString value)}") (lib.filterAttrs (_: v: v != null) env)
+      lib.mapAttrsToList
+        (var: value:
+          if builtins.match "[a-zA-Z_][a-zA-Z0-9_]*" var == null
+          then throw "mkShellEnvHook: invalid shell variable name '${var}'"
+          else "export ${var}=${lib.escapeShellArg (toString value)}")
+        (lib.filterAttrs (_: v: v != null) env)
     )
   )
 )

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -90,7 +90,6 @@ in {
           then throw "jackpkgs.gcp.profile contains invalid characters. Only [a-zA-Z0-9._-] are allowed."
           else ''
             export CLOUDSDK_CONFIG="$HOME/.config/gcloud-profiles/${gcpProfile}"
-            export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpProfile}/application_default_credentials.json"
             mkdir -p "$CLOUDSDK_CONFIG"
           ''
         )

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -7,19 +7,6 @@
   inherit (lib) mkIf;
   cfg = config.jackpkgs.shell;
   gcpProfile = lib.attrByPath ["jackpkgs" "gcp" "profile"] null config;
-  pulumiCfg = lib.attrByPath ["jackpkgs" "pulumi"] null config;
-  pulumiEnv =
-    if pulumiCfg != null && pulumiCfg.enable
-    then {
-      PULUMI_BACKEND_URL = pulumiCfg.backendUrl;
-      PULUMI_SECRETS_PROVIDER = pulumiCfg.secretsProvider;
-      PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
-      PULUMI_OPTION_NON_INTERACTIVE = "true";
-      PULUMI_OPTION_COLOR = "never";
-      PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
-      NODE_OPTIONS = "--async-context-frame";
-    }
-    else {};
 in {
   imports = [
     jackpkgsInputs.flake-root.flakeModule
@@ -93,19 +80,10 @@ in {
       ...
     }: let
       sysCfg = config.jackpkgs.shell;
-      mkShellEnvHook = import ../../lib/shell-env-hook.nix {inherit lib pkgs;};
 
       # Build shellHook segments as a list and join with newlines for safe concatenation.
-      # Durable environment variables are carried by setup hooks, not shellHook, so
-      # they propagate through downstream inputsFrom composition.
-      pulumiEnvHook =
-        if pulumiEnv == {}
-        then null
-        else
-          mkShellEnvHook {
-            name = "jackpkgs-pulumi-env-hook";
-            env = pulumiEnv;
-          };
+      # Durable environment variables are carried by setup hooks from pulumiDevShell,
+      # which is already included via sysCfg.inputsFrom (set by the pulumi module).
       shellHookParts =
         lib.optional (gcpProfile != null) (
           if builtins.match "[a-zA-Z0-9._-]+" gcpProfile == null
@@ -131,7 +109,7 @@ in {
               config.treefmt.build.devShell
             ]
             ++ sysCfg.inputsFrom;
-          packages = sysCfg.packages ++ lib.optional (pulumiEnvHook != null) pulumiEnvHook;
+          packages = sysCfg.packages;
 
           shellHook = lib.concatStringsSep "\n" shellHookParts;
         }

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -90,6 +90,7 @@ in {
           then throw "jackpkgs.gcp.profile contains invalid characters. Only [a-zA-Z0-9._-] are allowed."
           else ''
             export CLOUDSDK_CONFIG="$HOME/.config/gcloud-profiles/${gcpProfile}"
+            export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpProfile}/application_default_credentials.json"
             mkdir -p "$CLOUDSDK_CONFIG"
           ''
         )

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -14,6 +14,9 @@
       PULUMI_BACKEND_URL = pulumiCfg.backendUrl;
       PULUMI_SECRETS_PROVIDER = pulumiCfg.secretsProvider;
       PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
+      PULUMI_OPTION_NON_INTERACTIVE = "true";
+      PULUMI_OPTION_COLOR = "never";
+      PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
       NODE_OPTIONS = "--async-context-frame";
     }
     else {};
@@ -91,7 +94,18 @@ in {
     }: let
       sysCfg = config.jackpkgs.shell;
 
-      # Build shellHook segments as a list and join with newlines for safe concatenation
+      # Build shellHook segments as a list and join with newlines for safe concatenation.
+      # mkShell does not reliably propagate env attributes through inputsFrom, so
+      # critical environment variables are also exported here for composed shells.
+      pulumiEnvExports =
+        lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") pulumiEnv;
+      pulumiEnvHook =
+        if pulumiEnv == {}
+        then null
+        else
+          pkgs.makeSetupHook {name = "jackpkgs-pulumi-env-hook";} (
+            pkgs.writeText "jackpkgs-pulumi-env-hook.sh" (lib.concatStringsSep "\n" pulumiEnvExports)
+          );
       shellHookParts =
         lib.optional (gcpProfile != null) (
           if builtins.match "[a-zA-Z0-9._-]+" gcpProfile == null
@@ -106,11 +120,7 @@ in {
           lib.optional (cfg.welcome.message != null) ''echo ${lib.escapeShellArg cfg.welcome.message}''
           ++ lib.optional cfg.welcome.showJustHint ''echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
         )
-        ++ lib.optional (pulumiCfg != null && pulumiCfg.enable) ''
-          export PULUMI_BACKEND_URL=${lib.escapeShellArg pulumiCfg.backendUrl}
-          export PULUMI_SECRETS_PROVIDER=${lib.escapeShellArg pulumiCfg.secretsProvider}
-          export PULUMI_IGNORE_AMBIENT_PLUGINS=1
-        '';
+        ++ lib.optional (pulumiEnv != {}) (lib.concatStringsSep "\n" pulumiEnvExports);
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell (
         {
@@ -122,7 +132,7 @@ in {
               config.treefmt.build.devShell
             ]
             ++ sysCfg.inputsFrom;
-          packages = sysCfg.packages;
+          packages = sysCfg.packages ++ lib.optional (pulumiEnvHook != null) pulumiEnvHook;
           env = pulumiEnv;
 
           shellHook = lib.concatStringsSep "\n" shellHookParts;

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -93,19 +93,19 @@ in {
       ...
     }: let
       sysCfg = config.jackpkgs.shell;
+      mkShellEnvHook = import ../../lib/shell-env-hook.nix {inherit lib pkgs;};
 
       # Build shellHook segments as a list and join with newlines for safe concatenation.
-      # mkShell does not reliably propagate env attributes through inputsFrom, so
-      # critical environment variables are also exported here for composed shells.
-      pulumiEnvExports =
-        lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") pulumiEnv;
+      # Durable environment variables are carried by setup hooks, not shellHook, so
+      # they propagate through downstream inputsFrom composition.
       pulumiEnvHook =
         if pulumiEnv == {}
         then null
         else
-          pkgs.makeSetupHook {name = "jackpkgs-pulumi-env-hook";} (
-            pkgs.writeText "jackpkgs-pulumi-env-hook.sh" (lib.concatStringsSep "\n" pulumiEnvExports)
-          );
+          mkShellEnvHook {
+            name = "jackpkgs-pulumi-env-hook";
+            env = pulumiEnv;
+          };
       shellHookParts =
         lib.optional (gcpProfile != null) (
           if builtins.match "[a-zA-Z0-9._-]+" gcpProfile == null
@@ -119,8 +119,7 @@ in {
         ++ lib.optionals cfg.welcome.enable (
           lib.optional (cfg.welcome.message != null) ''echo ${lib.escapeShellArg cfg.welcome.message}''
           ++ lib.optional cfg.welcome.showJustHint ''echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
-        )
-        ++ lib.optional (pulumiEnv != {}) (lib.concatStringsSep "\n" pulumiEnvExports);
+        );
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell (
         {
@@ -133,7 +132,6 @@ in {
             ]
             ++ sysCfg.inputsFrom;
           packages = sysCfg.packages ++ lib.optional (pulumiEnvHook != null) pulumiEnvHook;
-          env = pulumiEnv;
 
           shellHook = lib.concatStringsSep "\n" shellHookParts;
         }

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -80,6 +80,7 @@ in {
       ...
     }: let
       sysCfg = config.jackpkgs.shell;
+      mkShellEnvHook = import ../../lib/shell-env-hook.nix {inherit lib pkgs;};
 
       # Build shellHook segments as a list and join with newlines for safe concatenation.
       # Durable environment variables are carried by setup hooks from pulumiDevShell,
@@ -109,13 +110,16 @@ in {
               config.treefmt.build.devShell
             ]
             ++ sysCfg.inputsFrom;
-          packages = sysCfg.packages;
+          packages = sysCfg.packages
+            ++ lib.optional (!cfg.direnv.showEnvDiff) (
+              mkShellEnvHook {
+                name = "jackpkgs-direnv-log-format-hook";
+                env = {DIRENV_LOG_FORMAT = "";};
+              }
+            );
 
           shellHook = lib.concatStringsSep "\n" shellHookParts;
         }
-        # Hide direnv environment variable diff output unless showEnvDiff is enabled.
-        # Passes DIRENV_LOG_FORMAT="" directly into mkShell's argument set.
-        // lib.optionalAttrs (!cfg.direnv.showEnvDiff) {DIRENV_LOG_FORMAT = "";}
       );
     };
   };

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -174,7 +174,9 @@ in {
         # cannot be carried by the setup hook (which single-quotes values).
         # Instead, export it via shellHook where shell expansion is available.
         adcShellHook = lib.optionalString (gcpCfg.profile != null) ''
-          export GOOGLE_APPLICATION_CREDENTIALS=$HOME/${lib.escapeShellArg ".config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json"}
+          _jackpkgs_pulumi_adc_rel_path=${lib.escapeShellArg ".config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json"}
+          export GOOGLE_APPLICATION_CREDENTIALS="$HOME/$_jackpkgs_pulumi_adc_rel_path"
+          unset _jackpkgs_pulumi_adc_rel_path
         '';
       in {
         jackpkgs.outputs.pulumiDevShell = pkgs.mkShell {

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -150,6 +150,9 @@ in {
 
         # ADC file path for the active gcp.profile (null-safe: only used when profile != null).
         # Validate that profile is set when authMode requires it.
+        # NOTE: This attrset is used only for the CI JSON env check (checks.pulumi-ci-env).
+        # The actual GOOGLE_APPLICATION_CREDENTIALS export is done via shellHook
+        # (adcShellHook) because the path contains $HOME which requires runtime expansion.
         profileAdcPath =
           if cfg.ci.authMode == "application-default-credentials" && gcpCfg.profile == null
           then throw "jackpkgs.pulumi.ci.authMode 'application-default-credentials' requires jackpkgs.gcp.profile to be set"
@@ -164,13 +167,23 @@ in {
 
         pulumiEnvHook = mkShellEnvHook {
           name = "jackpkgs-pulumi-env-hook";
-          env = pulumiBaseEnv // profileAdcPath;
+          env = pulumiBaseEnv;
         };
 
         ciPulumiEnvHook = mkShellEnvHook {
           name = "jackpkgs-ci-pulumi-env-hook";
-          env = ciPulumiEnv;
+          # Only literal (non-$HOME) env vars go in the setup hook.
+          # GOOGLE_APPLICATION_CREDENTIALS (if present) uses $HOME expansion
+          # and is exported via adcShellHook in the CI shell's shellHook.
+          env = pulumiBaseEnv;
         };
+
+        # ADC path for the active gcp.profile. This uses $HOME expansion so it
+        # cannot be carried by the setup hook (which single-quotes values).
+        # Instead, export it via shellHook where shell expansion is available.
+        adcShellHook = lib.optionalString (gcpCfg.profile != null) ''
+          export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json"
+        '';
       in {
         jackpkgs.outputs.pulumiDevShell = pkgs.mkShell {
           packages =
@@ -183,8 +196,9 @@ in {
               typescript
             ])
             ++ [pulumiEnvHook];
-          # Dev shell environment is carried by pulumiEnvHook so it is applied
-          # consistently by the same mechanism used for composed shells.
+          # Literal env vars are carried by pulumiEnvHook (setup hook).
+          # ADC path uses $HOME and must be set via shellHook for expansion.
+          shellHook = adcShellHook;
         };
 
         devShells.ci-pulumi = pkgs.mkShell {
@@ -195,7 +209,9 @@ in {
           #     WIF credentials are injected by the CI runner (google-github-actions/auth).
           #   "application-default-credentials" — set GOOGLE_APPLICATION_CREDENTIALS to
           #     the profile ADC file; requires jackpkgs.gcp.profile to be non-null.
-          # Environment is carried by ciPulumiEnvHook, not mkShell env attrs.
+          # Literal env vars are carried by ciPulumiEnvHook (setup hook).
+          # ADC path (when enabled) uses $HOME and is set via shellHook.
+          shellHook = lib.optionalString (cfg.ci.authMode == "application-default-credentials") adcShellHook;
         };
 
         jackpkgs.shell.inputsFrom = [

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -170,19 +170,11 @@ in {
           env = pulumiBaseEnv;
         };
 
-        ciPulumiEnvHook = mkShellEnvHook {
-          name = "jackpkgs-ci-pulumi-env-hook";
-          # Only literal (non-$HOME) env vars go in the setup hook.
-          # GOOGLE_APPLICATION_CREDENTIALS (if present) uses $HOME expansion
-          # and is exported via adcShellHook in the CI shell's shellHook.
-          env = pulumiBaseEnv;
-        };
-
         # ADC path for the active gcp.profile. This uses $HOME expansion so it
         # cannot be carried by the setup hook (which single-quotes values).
         # Instead, export it via shellHook where shell expansion is available.
         adcShellHook = lib.optionalString (gcpCfg.profile != null) ''
-          export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json"
+          export GOOGLE_APPLICATION_CREDENTIALS=$HOME/${lib.escapeShellArg ".config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json"}
         '';
       in {
         jackpkgs.outputs.pulumiDevShell = pkgs.mkShell {
@@ -202,14 +194,14 @@ in {
         };
 
         devShells.ci-pulumi = pkgs.mkShell {
-          packages = config.jackpkgs.pulumi.ci.packages ++ [ciPulumiEnvHook];
+          packages = config.jackpkgs.pulumi.ci.packages ++ [pulumiEnvHook];
 
           # CI shell auth strategy is controlled by jackpkgs.pulumi.ci.authMode:
           #   "workload-identity" (default) — do not bake GOOGLE_APPLICATION_CREDENTIALS;
           #     WIF credentials are injected by the CI runner (google-github-actions/auth).
           #   "application-default-credentials" — set GOOGLE_APPLICATION_CREDENTIALS to
           #     the profile ADC file; requires jackpkgs.gcp.profile to be non-null.
-          # Literal env vars are carried by ciPulumiEnvHook (setup hook).
+          # Literal env vars are carried by pulumiEnvHook (setup hook).
           # ADC path (when enabled) uses $HOME and is set via shellHook.
           shellHook = lib.optionalString (cfg.ci.authMode == "application-default-credentials") adcShellHook;
         };

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -130,6 +130,7 @@ in {
         ...
       }: let
         pulumiExe = lib.getExe' pkgs.pulumi-bin "pulumi";
+        mkShellEnvHook = import ../../lib/shell-env-hook.nix {inherit lib pkgs;};
         stacks = cfg.stacks;
         defaultStack = cfg.defaultStack;
 
@@ -160,32 +161,41 @@ in {
         ciPulumiEnv =
           pulumiBaseEnv
           // lib.optionalAttrs (cfg.ci.authMode == "application-default-credentials") profileAdcPath;
-      in {
-        jackpkgs.outputs.pulumiDevShell = pkgs.mkShell {
-          packages = with pkgs; [
-            pulumi-bin
-            nodejs
-            jq
-            just
-            (google-cloud-sdk.withExtraComponents [google-cloud-sdk.components.gke-gcloud-auth-plugin])
-            typescript
-          ];
-          # Dev shell always sets GOOGLE_APPLICATION_CREDENTIALS when a profile is
-          # active: Go-based GCP clients (including Pulumi providers) do not honour
-          # CLOUDSDK_CONFIG and require this explicit env var (see issue #182 and
-          # ADR 027).
+
+        pulumiEnvHook = mkShellEnvHook {
+          name = "jackpkgs-pulumi-env-hook";
           env = pulumiBaseEnv // profileAdcPath;
         };
 
+        ciPulumiEnvHook = mkShellEnvHook {
+          name = "jackpkgs-ci-pulumi-env-hook";
+          env = ciPulumiEnv;
+        };
+      in {
+        jackpkgs.outputs.pulumiDevShell = pkgs.mkShell {
+          packages =
+            (with pkgs; [
+              pulumi-bin
+              nodejs
+              jq
+              just
+              (google-cloud-sdk.withExtraComponents [google-cloud-sdk.components.gke-gcloud-auth-plugin])
+              typescript
+            ])
+            ++ [pulumiEnvHook];
+          # Dev shell environment is carried by pulumiEnvHook so it is applied
+          # consistently by the same mechanism used for composed shells.
+        };
+
         devShells.ci-pulumi = pkgs.mkShell {
-          packages = config.jackpkgs.pulumi.ci.packages;
+          packages = config.jackpkgs.pulumi.ci.packages ++ [ciPulumiEnvHook];
 
           # CI shell auth strategy is controlled by jackpkgs.pulumi.ci.authMode:
           #   "workload-identity" (default) — do not bake GOOGLE_APPLICATION_CREDENTIALS;
           #     WIF credentials are injected by the CI runner (google-github-actions/auth).
           #   "application-default-credentials" — set GOOGLE_APPLICATION_CREDENTIALS to
           #     the profile ADC file; requires jackpkgs.gcp.profile to be non-null.
-          env = ciPulumiEnv;
+          # Environment is carried by ciPulumiEnvHook, not mkShell env attrs.
         };
 
         jackpkgs.shell.inputsFrom = [

--- a/modules/flake-parts/pulumi.nix
+++ b/modules/flake-parts/pulumi.nix
@@ -134,6 +134,16 @@ in {
         stacks = cfg.stacks;
         defaultStack = cfg.defaultStack;
 
+        # Fail at evaluation time (not just in CI checks) when ADC authMode
+        # is selected without a gcp.profile. Without this, the devShell would
+        # silently skip GOOGLE_APPLICATION_CREDENTIALS.
+        adcProfileRequired =
+          cfg.ci.authMode == "application-default-credentials"
+          && gcpCfg.profile == null;
+        assertAdcProfile =
+          lib.asserts.assertMsg (!adcProfileRequired)
+            "jackpkgs.pulumi.ci.authMode 'application-default-credentials' requires jackpkgs.gcp.profile to be set";
+
         # Shared base env vars present in every Pulumi shell.
         pulumiBaseEnv = {
           PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
@@ -154,12 +164,9 @@ in {
         # The actual GOOGLE_APPLICATION_CREDENTIALS export is done via shellHook
         # (adcShellHook) because the path contains $HOME which requires runtime expansion.
         profileAdcPath =
-          if cfg.ci.authMode == "application-default-credentials" && gcpCfg.profile == null
-          then throw "jackpkgs.pulumi.ci.authMode 'application-default-credentials' requires jackpkgs.gcp.profile to be set"
-          else
-            lib.optionalAttrs (gcpCfg.profile != null) {
-              GOOGLE_APPLICATION_CREDENTIALS = "$HOME/.config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json";
-            };
+          lib.optionalAttrs (gcpCfg.profile != null) {
+            GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpCfg.profile}/application_default_credentials.json";
+          };
 
         ciPulumiEnv =
           pulumiBaseEnv
@@ -192,7 +199,8 @@ in {
             ++ [pulumiEnvHook];
           # Literal env vars are carried by pulumiEnvHook (setup hook).
           # ADC path uses $HOME and must be set via shellHook for expansion.
-          shellHook = adcShellHook;
+          # Force ADC profile assertion to evaluate at shell build time.
+          shellHook = builtins.seq assertAdcProfile adcShellHook;
         };
 
         devShells.ci-pulumi = pkgs.mkShell {

--- a/tests/pulumi.nix
+++ b/tests/pulumi.nix
@@ -36,27 +36,8 @@
     };
   };
 
-  expectedEnv = {
-    PULUMI_IGNORE_AMBIENT_PLUGINS = "1";
-    PULUMI_BACKEND_URL = "s3://pulumi-state";
-    PULUMI_SECRETS_PROVIDER = "awskms://alias/pulumi";
-    PULUMI_OPTION_NON_INTERACTIVE = "true";
-    PULUMI_OPTION_COLOR = "never";
-    PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
-    NODE_OPTIONS = "--async-context-frame";
-  };
-
-  hasExpectedEnv = drv:
-    lib.all (name: drv.${name} == expectedEnv.${name}) (builtins.attrNames expectedEnv);
-
-  expectedShellHookExports =
-    map (name: "export ${name}=${lib.escapeShellArg expectedEnv.${name}}") (builtins.attrNames expectedEnv);
-
-  hasExpectedShellHookExports = drv:
-    lib.all (needle: lib.hasInfix needle drv.shellHook) expectedShellHookExports;
-
-  hasPulumiEnvSetupHook = drv:
-    lib.any (input: lib.hasInfix "jackpkgs-pulumi-env-hook" (toString input)) (drv.nativeBuildInputs or []);
+  hasPulumiEnvSetupHook = hookName: drv:
+    lib.any (input: lib.hasInfix hookName (toString input)) (drv.nativeBuildInputs or []);
 
   defaultStacks = [
     {
@@ -71,23 +52,21 @@ in {
   testPulumiDevShellSetsPulumiCliDefaults = let
     perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
   in {
-    expr = hasExpectedEnv perSystemCfg.jackpkgs.outputs.pulumiDevShell;
+    expr = hasPulumiEnvSetupHook "jackpkgs-pulumi-env-hook" perSystemCfg.jackpkgs.outputs.pulumiDevShell;
     expected = true;
   };
 
   testCiPulumiDevShellSetsPulumiCliDefaults = let
     perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
   in {
-    expr = hasExpectedEnv perSystemCfg.devShells.ci-pulumi;
+    expr = hasPulumiEnvSetupHook "jackpkgs-ci-pulumi-env-hook" perSystemCfg.devShells.ci-pulumi;
     expected = true;
   };
 
   testComposedDevShellExportsPulumiEnv = let
     perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
   in {
-    expr =
-      hasExpectedShellHookExports perSystemCfg.jackpkgs.outputs.devShell
-      && hasPulumiEnvSetupHook perSystemCfg.jackpkgs.outputs.devShell;
+    expr = hasPulumiEnvSetupHook "jackpkgs-pulumi-env-hook" perSystemCfg.jackpkgs.outputs.devShell;
     expected = true;
   };
 

--- a/tests/pulumi.nix
+++ b/tests/pulumi.nix
@@ -59,7 +59,7 @@ in {
   testCiPulumiDevShellSetsPulumiCliDefaults = let
     perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
   in {
-    expr = hasPulumiEnvSetupHook "jackpkgs-ci-pulumi-env-hook" perSystemCfg.devShells.ci-pulumi;
+    expr = hasPulumiEnvSetupHook "jackpkgs-pulumi-env-hook" perSystemCfg.devShells.ci-pulumi;
     expected = true;
   };
 

--- a/tests/pulumi.nix
+++ b/tests/pulumi.nix
@@ -6,14 +6,19 @@
   flakeParts = inputs.flake-parts.lib;
   libModule = import ../modules/flake-parts/lib.nix {jackpkgsInputs = inputs;};
   pkgsModule = import ../modules/flake-parts/pkgs.nix {jackpkgsInputs = inputs;};
+  checksModule = import ../modules/flake-parts/checks.nix {jackpkgsInputs = inputs;};
   devshellModule = import ../modules/flake-parts/devshell.nix {jackpkgsInputs = inputs;};
-  gcpModule = import ../modules/flake-parts/gcp.nix {jackpkgsInputs = inputs;};
+  fmtModule = import ../modules/flake-parts/fmt.nix {jackpkgsInputs = inputs;};
+  justModule = import ../modules/flake-parts/just.nix {jackpkgsInputs = inputs;};
+  nodejsModule = import ../modules/flake-parts/nodejs.nix {jackpkgsInputs = inputs;};
+  preCommitModule = import ../modules/flake-parts/pre-commit.nix {jackpkgsInputs = inputs;};
   pulumiModule = import ../modules/flake-parts/pulumi.nix {jackpkgsInputs = inputs;};
+  quartoModule = import ../modules/flake-parts/quarto.nix {jackpkgsInputs = inputs;};
 
   evalFlake = modules:
     flakeParts.evalFlakeModule {inherit inputs;} {
       systems = [system];
-      imports = [libModule pkgsModule devshellModule gcpModule] ++ modules ++ [pulumiModule];
+      imports = [libModule pkgsModule checksModule devshellModule fmtModule justModule nodejsModule preCommitModule quartoModule] ++ modules ++ [pulumiModule];
     };
 
   getPerSystemCfg = modules: (evalFlake modules).config.perSystem system;
@@ -38,10 +43,20 @@
     PULUMI_OPTION_NON_INTERACTIVE = "true";
     PULUMI_OPTION_COLOR = "never";
     PULUMI_OPTION_SUPPRESS_PROGRESS = "true";
+    NODE_OPTIONS = "--async-context-frame";
   };
 
   hasExpectedEnv = drv:
     lib.all (name: drv.${name} == expectedEnv.${name}) (builtins.attrNames expectedEnv);
+
+  expectedShellHookExports =
+    map (name: "export ${name}=${lib.escapeShellArg expectedEnv.${name}}") (builtins.attrNames expectedEnv);
+
+  hasExpectedShellHookExports = drv:
+    lib.all (needle: lib.hasInfix needle drv.shellHook) expectedShellHookExports;
+
+  hasPulumiEnvSetupHook = drv:
+    lib.any (input: lib.hasInfix "jackpkgs-pulumi-env-hook" (toString input)) (drv.nativeBuildInputs or []);
 
   defaultStacks = [
     {
@@ -64,6 +79,15 @@ in {
     perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
   in {
     expr = hasExpectedEnv perSystemCfg.devShells.ci-pulumi;
+    expected = true;
+  };
+
+  testComposedDevShellExportsPulumiEnv = let
+    perSystemCfg = getPerSystemCfg [(mkConfigModule {})];
+  in {
+    expr =
+      hasExpectedShellHookExports perSystemCfg.jackpkgs.outputs.devShell
+      && hasPulumiEnvSetupHook perSystemCfg.jackpkgs.outputs.devShell;
     expected = true;
   };
 


### PR DESCRIPTION
## Summary
- export the full shared Pulumi devshell environment from `jackpkgs.shell`, including the PR #205 `PULUMI_OPTION_*` defaults and `NODE_OPTIONS=--async-context-frame`
- add a setup hook package to `jackpkgs.outputs.devShell` so downstream shells that compose it via `inputsFrom` receive the variables
- extend Pulumi tests to cover the composed-shell propagation path and update README docs

## Diagnosis
`mkShell` does not reliably propagate `env` or `shellHook` from derivations included through `inputsFrom`. PR #205 added the non-interactive Pulumi defaults to `pulumiDevShell` / `ci-pulumi`, but consumers like yard wrap `config.jackpkgs.outputs.devShell` in another `mkShell`, so those env attrs did not reach the final interactive shell. The same issue applied to the later `NODE_OPTIONS` fix.

The reliable boundary is build inputs/native build inputs, so this PR carries the exports in a setup hook package as well as keeping direct shell exports for `jackpkgs.outputs.devShell` itself.

## Validation
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); in { pulumiDevShell = flake.tests.systems.x86_64-linux.pulumi.testPulumiDevShellSetsPulumiCliDefaults.expr; ciPulumi = flake.tests.systems.x86_64-linux.pulumi.testCiPulumiDevShellSetsPulumiCliDefaults.expr; composed = flake.tests.systems.x86_64-linux.pulumi.testComposedDevShellExportsPulumiEnv.expr; }'`
- `nix flake check --impure`
- Verified against yard with `nix develop --ignore-environment --override-input jackpkgs /private/tmp/jackpkgs-envfix-205 --command ...`; the composed shell shows all expected `PULUMI_*` vars plus `NODE_OPTIONS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Pulumi and related environment variables are injected into dev shells (moving from `env` attrs to setup-hook + `shellHook`), which can affect downstream shell composition and CI auth behavior if misconfigured.
> 
> **Overview**
> Fixes Pulumi environment propagation for downstream dev shells that compose `jackpkgs` shells via `inputsFrom` by moving durable exports into a shared setup hook.
> 
> Adds `lib/shell-env-hook.nix` to generate `makeSetupHook` packages from an env attrset, then updates `pulumi.nix` to attach a single `jackpkgs-pulumi-env-hook` (including `PULUMI_OPTION_*` defaults and `NODE_OPTIONS`) to both `pulumiDevShell` and `ci-pulumi`, while keeping `$HOME`-dependent `GOOGLE_APPLICATION_CREDENTIALS` in `shellHook` and asserting ADC mode requires `jackpkgs.gcp.profile`.
> 
> Updates the composed `devShell` to stop duplicating Pulumi `env` and instead rely on the Pulumi shell fragment via `inputsFrom`; also switches the direnv log-format tweak to a setup hook. Tests are updated to assert hook presence in `pulumiDevShell`, `ci-pulumi`, and the composed `devShell`, and docs add ADR-034 plus README notes about the shared Pulumi env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a9581735601bbb2e2c6fae05cb95ba6f17b6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->