### PR TITLE
feat(imessage-bridge): add package and nix-darwin launchd module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
           csharpier = pkgs.callPackage ./pkgs/csharpier {};
           docfx = pkgs.callPackage ./pkgs/docfx {};
           epub2tts = pkgs.callPackage ./pkgs/epub2tts {};
+          imessage-bridge = pkgs.callPackage ./pkgs/imessage-bridge {};
           lean = pkgs.callPackage ./pkgs/lean {};
           openchamber = pkgs.callPackage ./pkgs/openchamber {
             opencode = inputs.llm-agents.packages.${system}.opencode;
@@ -206,6 +207,7 @@
             lib = jackLib;
             modules = import ./modules;
             homeManagerModules = import ./modules/home-manager;
+            darwinModules = import ./modules/nix-darwin;
             overlays = import ./overlays;
           }
           // platformFilteredPackages;
@@ -388,6 +390,9 @@
       flake = {
         # Expose overlays for backward compatibility
         overlays.default = import ./overlay.nix;
+
+        # Expose nix-darwin modules
+        darwinModules.imessage-bridge = import ./modules/nix-darwin/imessage-bridge.nix;
 
         # Expose lib for backward compatibility
         lib = inputs.nixpkgs.lib.extend (

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./imessage-bridge.nix
+  ];
+}

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -36,10 +36,9 @@ in {
     };
 
     logDir = mkOption {
-      type = types.path;
-      default = "/tmp";
-      defaultText = literalExpression "/tmp";
-      description = "Directory for StandardOutPath and StandardErrorPath logs.";
+      type = types.nullOr types.path;
+      default = null;
+      description = "Directory for StandardOutPath and StandardErrorPath logs. When null, launchd defaults apply.";
     };
   };
 
@@ -52,12 +51,15 @@ in {
         ++ lib.optional cfg.noBonjour "--no-bonjour"
       );
 
-      serviceConfig = {
-        RunAtLoad = true;
-        KeepAlive = true;
-        StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
-        StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
-      };
+      serviceConfig =
+        {
+          RunAtLoad = true;
+          KeepAlive = true;
+        }
+        // lib.optionalAttrs (cfg.logDir != null) {
+          StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
+          StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
+        };
     };
   };
 }

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -38,20 +38,18 @@ in {
 
   config = mkIf cfg.enable {
     launchd.user.agents.imessage-bridge = {
+      command = lib.escapeShellArgs (
+        [(lib.getExe cfg.package)]
+        ++ ["--port" (toString cfg.port)]
+        ++ lib.optionals (cfg.bonjourName != null) ["--name" cfg.bonjourName]
+        ++ lib.optional cfg.noBonjour "--no-bonjour"
+      );
+
       serviceConfig = {
-        ProgramArguments =
-          [
-            (lib.getExe cfg.package)
-            "--port"
-            (toString cfg.port)
-          ]
-          ++ lib.optionals (cfg.bonjourName != null) [
-            "--name"
-            cfg.bonjourName
-          ]
-          ++ lib.optional cfg.noBonjour "--no-bonjour";
         RunAtLoad = true;
         KeepAlive = true;
+        StandardOutPath = "/tmp/imessage-bridge.log";
+        StandardErrorPath = "/tmp/imessage-bridge.err.log";
       };
     };
   };

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.imessage-bridge;
+in {
+  options.services.imessage-bridge = {
+    enable = mkEnableOption "iMessage Bridge HTTP server";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.imessage-bridge;
+      defaultText = literalExpression "pkgs.imessage-bridge";
+      description = "imessage-bridge package to use.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8432;
+      description = "Port to listen on.";
+    };
+
+    bonjourName = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Bonjour service name. Defaults to hostname.";
+    };
+
+    noBonjour = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Disable Bonjour/mDNS service registration.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    launchd.user.agents.imessage-bridge = {
+      serviceConfig = {
+        ProgramArguments =
+          [
+            (lib.getExe cfg.package)
+            "--port"
+            (toString cfg.port)
+          ]
+          ++ lib.optionals (cfg.bonjourName != null) [
+            "--name"
+            cfg.bonjourName
+          ]
+          ++ lib.optional cfg.noBonjour "--no-bonjour";
+        RunAtLoad = true;
+        KeepAlive = true;
+      };
+    };
+  };
+}

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -34,6 +34,13 @@ in {
       default = false;
       description = "Disable Bonjour/mDNS service registration.";
     };
+
+    logDir = mkOption {
+      type = types.path;
+      default = "/tmp";
+      defaultText = literalExpression "/tmp";
+      description = "Directory for StandardOutPath and StandardErrorPath logs.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -48,8 +55,8 @@ in {
       serviceConfig = {
         RunAtLoad = true;
         KeepAlive = true;
-        StandardOutPath = "/tmp/imessage-bridge.log";
-        StandardErrorPath = "/tmp/imessage-bridge.err.log";
+        StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
+        StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
       };
     };
   };

--- a/overlay.nix
+++ b/overlay.nix
@@ -15,6 +15,7 @@ else let
     csharpier = super.callPackage ./pkgs/csharpier {};
     docfx = super.callPackage ./pkgs/docfx {};
     epub2tts = super.callPackage ./pkgs/epub2tts {};
+    imessage-bridge = super.callPackage ./pkgs/imessage-bridge {};
     lean = super.callPackage ./pkgs/lean {};
     tod = super.callPackage ./pkgs/tod {};
   };
@@ -24,6 +25,7 @@ else let
       lib = jackLib;
       modules = import ./modules;
       homeManagerModules = import ./modules/home-manager;
+      darwinModules = import ./modules/nix-darwin;
       overlays = import ./overlays;
     }
     // jackLib.filterByPlatforms super.system allPackages;

--- a/pkgs/imessage-bridge/default.nix
+++ b/pkgs/imessage-bridge/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+}:
+stdenv.mkDerivation rec {
+  pname = "imessage-bridge";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "greghughespdx";
+    repo = "imessage-bridge";
+    rev = "v${version}";
+    hash = "sha256-4RwXAoIqz7Xahwu30g9UW1+eNC6iyrd+F5vOs0Yu41E=";
+  };
+
+  buildInputs = [python3];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp bridge.py $out/bin/imessage-bridge
+    chmod +x $out/bin/imessage-bridge
+    patchShebangs $out/bin/imessage-bridge
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Zero-dependency HTTP bridge for macOS iMessage (chat.db + AppleScript)";
+    homepage = "https://github.com/greghughespdx/imessage-bridge";
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.darwin;
+    mainProgram = "imessage-bridge";
+  };
+}

--- a/pkgs/imessage-bridge/default.nix
+++ b/pkgs/imessage-bridge/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-4RwXAoIqz7Xahwu30g9UW1+eNC6iyrd+F5vOs0Yu41E=";
   };
 
-  buildInputs = [python3];
+  nativeBuildInputs = [python3];
 
   dontBuild = true;
 


### PR DESCRIPTION
## Summary

Package [greghughespdx/imessage-bridge](https://github.com/greghughespdx/imessage-bridge) v0.1.0 — a zero-dependency Python HTTP server that exposes iMessage send/receive via `chat.db` and AppleScript.

### New files

- **`pkgs/imessage-bridge/default.nix`** — trivial `stdenv.mkDerivation` (single-file Python, stdlib only, `patchShebangs` for nix store python3)
- **`modules/nix-darwin/imessage-bridge.nix`** — nix-darwin module with `services.imessage-bridge` options:
  - `enable` — enable the LaunchAgent
  - `package` — override the package (default: `pkgs.imessage-bridge`)
  - `port` — listen port (default: `8432`)
  - `bonjourName` — Bonjour/mDNS service name (default: hostname)
  - `noBonjour` — disable Bonjour registration
  - Configures a user-scoped LaunchAgent with `RunAtLoad = true` and `KeepAlive = true`
- **`modules/nix-darwin/default.nix`** — module directory entry point

### Wiring

- Added to `allPackages` in `flake.nix` and `overlay.nix`
- Exposed as `darwinModules.imessage-bridge` flake output
- Exposed in `overlay.nix` as `darwinModules` attr

### API surface (from bridge.py)

| Endpoint | Description |
|---|---|
| `GET /messages?after=<unix_ms>` | Returns JSON array of messages since timestamp |
| `POST /send` | Send iMessage via AppleScript (`{chat_id, text}`) |
| `GET /info` | Bridge metadata (name, hostname, port, version) |

### One-time manual steps (not automatable)

1. **Full Disk Access**: Grant to the nix-wrapped python binary in System Settings > Privacy & Security > Full Disk Access. Use `Cmd+Shift+G` to navigate to `/nix/store/...-python3-.../bin/python3`.
2. **Automation permission**: When the bridge first tries to send via AppleScript, macOS prompts "Python wants to control Messages.app" — click Allow.
3. **iMessage signed in**: Messages.app must be signed into an Apple ID.
4. **SMS support** (optional): Enable Text Message Forwarding on iPhone > point to hermione.

### Usage in a nix-darwin config

```nix
{
  inputs.jackpkgs.url = "github:jmmaloney4/jackpkgs";

  outputs = { nixpkgs, jackpkgs, ... }: {
    darwinConfigurations.hermione = nixpkgs.lib.nixosSystem {
      modules = [
        jackpkgs.darwinModules.imessage-bridge
        {
          services.imessage-bridge = {
            enable = true;
            port = 8432;
          };
        }
      ];
    };
  };
}
```

### Why NOT BlueBubbles

BlueBubbles Server is an Electron GUI app with no CLI/headless mode (issue #733 crashes on null window). Not suitable for declarative nix-darwin management. imessage-bridge is ~200 lines of stdlib-only Python with a proper HTTP daemon.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new darwin-only package and a nix-darwin `launchd` user agent module; existing users are unaffected unless they opt in by enabling the service.
> 
> **Overview**
> Adds a new darwin-only `imessage-bridge` package (v0.1.0) and wires it into the flake and overlay outputs so it can be consumed as `pkgs.imessage-bridge`.
> 
> Introduces a nix-darwin module `services.imessage-bridge` that starts the bridge as a user `launchd` agent, with options for `port`, Bonjour naming/disablement, package override, and optional log paths; exposes it via `darwinModules.imessage-bridge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f449699cbf17d6e809ef3869c15ce2b490b42cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->