### PR TITLE
feat(just): add nix-unit tests and docs for ruffPackage env selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ in {
   - Options under `jackpkgs.just` to replace tool packages used by generated `just` recipes:
     - `biomePackage`, `direnvPackage`, `fdPackage`, `flakeIterPackage`, `googleCloudSdkPackage`, `jqPackage`, `mypyPackage`, `nbstripoutPackage`, `preCommitPackage`, `pulumiPackage`, `ruffPackage`
     - `mypyPackage` defaults to the dev-tools Python environment used by `checks` / `pre-commit`
+    - `ruffPackage` defaults to the same dev-tools Python environment as `mypyPackage`
     - `pulumiBackendUrl` (nullable string)
   - Options under `jackpkgs.gcp`:
     - `iamOrg` (nullable string, default `null`) - GCP IAM organization domain for the `auth` recipe. When set, `just auth` uses `--account=$GCP_ACCOUNT_USER@<domain>` where `GCP_ACCOUNT_USER` defaults to `$USER`. Example: `iamOrg = "example.com";`

--- a/tests/just.nix
+++ b/tests/just.nix
@@ -89,7 +89,7 @@
     builtins.derivation {
       inherit name system;
       builder = "/bin/sh";
-      args = ["-c" "mkdir -p \"$out/bin\" && touch \"$out/bin/${name}\" \"$out/bin/mypy\""];
+      args = ["-c" "mkdir -p \"$out/bin\" && touch \"$out/bin/${name}\" \"$out/bin/mypy\" \"$out/bin/ruff\""];
     };
 
   mkConfigModule = {
@@ -170,6 +170,40 @@ in {
     ];
   in {
     expr = perSystemCfg.jackpkgs.just.mypyPackage == defaultEnv;
+    expected = true;
+  };
+
+  testJustRuffPackagePrefersDevToolsEnv = let
+    devToolsEnv = mkTestPackage "python-dev-tools";
+    perSystemCfg = getPerSystemCfg [
+      (mkConfigModule {
+        pythonEnvs.dev = devToolsEnv;
+        pythonDefaultEnv = mkTestPackage "python-default";
+        extraChecks.python.mypy.enable = false;
+      })
+      {
+        jackpkgs.python.environments.dev = {
+          editable = false;
+          includeGroups = true;
+        };
+      }
+    ];
+  in {
+    expr = perSystemCfg.jackpkgs.just.ruffPackage == devToolsEnv;
+    expected = true;
+  };
+
+  testJustRuffPackageFallsBackToPythonDefaultEnv = let
+    defaultEnv = mkTestPackage "python-default";
+    perSystemCfg = getPerSystemCfg [
+      (mkConfigModule {
+        pythonDefaultEnv = defaultEnv;
+        extraChecks.python.mypy.enable = false;
+        withPythonWorkspace = false;
+      })
+    ];
+  in {
+    expr = perSystemCfg.jackpkgs.just.ruffPackage == defaultEnv;
     expected = true;
   };
 }


### PR DESCRIPTION
## Context

`jackpkgs.just.ruffPackage` was already wired through `selectDevToolsPackage` (matching the mypy alignment from #216), and the generated `lint` recipe already uses `lib.getExe'` for multi-binary env support. The code changes from #216 covered `ruffPackage` too.

What was missing: **test coverage** and **README documentation**.

## Changes

- **nix-unit tests** (`tests/just.nix`):
  - `testJustRuffPackagePrefersDevToolsEnv` -- verifies ruffPackage selects the dev-tools Python env when available
  - `testJustRuffPackageFallsBackToPythonDefaultEnv` -- verifies fallback to `pythonDefaultEnv`
  - Updated `mkTestPackage` to create both `mypy` and `ruff` binaries in test envs

- **README** (`README.md`):
  - Added `ruffPackage defaults to the same dev-tools Python environment as mypyPackage` to the just-module docs

Closes #218

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation and nix-unit tests around `jackpkgs.just.ruffPackage` defaults without changing runtime selection logic.
> 
> **Overview**
> **Adds coverage and documentation for `jackpkgs.just.ruffPackage` defaults.**
> 
> Updates `README.md` to state that `ruffPackage` defaults to the same dev-tools Python environment as `mypyPackage`.
> 
> Extends `tests/just.nix` to create a `ruff` binary in test envs and adds two nix-unit tests verifying `ruffPackage` prefers the dev-tools env when available and otherwise falls back to `pythonDefaultEnv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc95f7eafa7f7c8d3b1a2a01461efb0f6a92424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->