### PR TITLE
docs(readme): add tombstone for removed openchamber package

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,8 @@ ______________________________________________________________________
 
 ## Packages available
 
+> **Removed packages:** `openchamber` (removed in e09c5ba, PR #247). The `llm-agents` and `bun2nix` flake inputs were also removed.
+
 - `csharpier` - C# formatter
 - `docfx` - .NET docs generator
 - `epub2tts` - EPUB -> TTS


### PR DESCRIPTION
Adds a tombstone note to the Packages section noting that openchamber was removed in e09c5ba (PR #247).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a note about a previously removed package; no runtime, build, or security impact.
> 
> **Overview**
> Updates `README.md`’s **Packages available** section to add a tombstone note that `openchamber` was removed (commit `e09c5ba`, PR `#247`) and that the `llm-agents` and `bun2nix` flake inputs were also removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f294599ee2e6b77fffee7bff9301d8688e9a087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->