### PR TITLE
feat(imessage-bridge): add system LaunchDaemon mode with user option

### DIFF
--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -13,7 +13,7 @@ with lib; let
     ++ lib.optionals (cfg.bonjourName != null) ["--name" cfg.bonjourName]
     ++ lib.optional cfg.noBonjour "--no-bonjour";
 
-  bridgeCmd = lib.escapeShellArgs bridgeArgs;
+  bridgeCmd = "exec " + lib.escapeShellArgs bridgeArgs;
 
   # Effective log directory: explicit cfg.logDir, or /var/log/imessage-bridge
   # for daemon mode. Null means no log capture (user agent default).
@@ -30,7 +30,7 @@ with lib; let
   # generated system activation profile for some configurations.
   # install -d is fully idempotent.
   stateSetup = lib.optionalString (effectiveLogDir != null) ''
-    install -d -o root -g wheel ${escapeShellArg effectiveLogDir}
+    install -d -o root -g wheel ${escapeShellArg (toString effectiveLogDir)}
   '';
 
   logPaths =
@@ -101,7 +101,7 @@ in {
       launchd.daemons.imessage-bridge = {
         script = ''
           ${stateSetup}
-          exec su -m ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
+          exec su -l ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
         '';
         serviceConfig =
           {

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -88,7 +88,7 @@ in {
       launchd.daemons.imessage-bridge = {
         script = ''
           ${stateSetup}
-          exec su -m ${escapeShellArg cfg.user} -c ${bridgeCmd}
+          exec su -m ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
         '';
         serviceConfig = {
           RunAtLoad = true;

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -93,7 +93,7 @@ in {
       launchd.daemons.imessage-bridge = {
         script = ''
           ${stateSetup}
-          exec su -m ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
+          exec su -m ${escapeShellArg cfg.user} -c ${bridgeCmd}
         '';
         serviceConfig = {
           RunAtLoad = true;

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -45,7 +45,7 @@ with lib; let
   # profile scripts.
   daemonScript = pkgs.writeShellScript "imessage-bridge-as-${cfg.user}" ''
     export HOME=${escapeShellArg "/Users/${cfg.user}"}
-    exec ${bridgeCmd}
+    ${bridgeCmd}
   '';
 in {
   options.services.imessage-bridge = {

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -21,16 +21,8 @@ with lib; let
   # generated system activation profile for some configurations.
   # install -d is fully idempotent.
   stateSetup = ''
-    install -d -o root -g wheel '${cfg.logDir}'
+    install -d -o root -g wheel ${escapeShellArg cfg.logDir}
   '';
-
-  # Default log directory depends on the mode:
-  #   system daemon -> /var/log/imessage-bridge (root-owned, stateSetup creates it)
-  #   user agent   -> ~/Library/Logs (user-writable, no setup needed)
-  defaultLogDir =
-    if cfg.user != null
-    then "/var/log/imessage-bridge"
-    else "/Users/${cfg.user or "jack"}/Library/Logs";
 in {
   options.services.imessage-bridge = {
     enable = mkEnableOption "iMessage Bridge HTTP server";
@@ -75,10 +67,13 @@ in {
 
     logDir = mkOption {
       type = types.path;
-      default = defaultLogDir;
+      default =
+        if cfg.user != null
+        then "/var/log/imessage-bridge"
+        else throw "services.imessage-bridge.logDir must be set when user is null (user agent mode)";
       defaultText = literalExpression ''
-        if cfg.user != null then "/var/log/imessage-bridge"
-        else "/Users/''${cfg.user or "jack"}/Library/Logs"
+        "/var/log/imessage-bridge" when user is set;
+        must be explicitly set in user agent mode
       '';
       description = "Directory for StandardOutPath and StandardErrorPath logs.";
     };

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -36,7 +36,7 @@ with lib; let
   logPaths = lib.optionalAttrs (effectiveLogDir != null) {
     StandardOutPath = "${toString effectiveLogDir}/imessage-bridge.log";
     StandardErrorPath = "${toString effectiveLogDir}/imessage-bridge.err.log";
-    };
+  };
 
   # Wrapper script for system daemon mode: sets HOME to the target user's
   # home directory so the bridge can find ~/Library/Messages/chat.db.

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -72,13 +72,12 @@ in {
     };
   };
 
-  config = mkIf cfg.enable (
-    if cfg.user != null
-    then {
-      # System LaunchDaemon mode (PR 513 pattern).
-      # Runs as root for state setup, drops to cfg.user for bridge execution.
-      # Uses `script` (not `command`) so nix-darwin generates a wait4path
-      # guard for the Nix store volume.
+  config = mkIf cfg.enable (mkMerge [
+    # System LaunchDaemon mode (PR 513 pattern).
+    # Runs as root for state setup, drops to cfg.user for bridge execution.
+    # Uses `script` (not `command`) so nix-darwin generates a wait4path
+    # guard for the Nix store volume.
+    (mkIf (cfg.user != null) {
       launchd.daemons.imessage-bridge = {
         script = ''
           ${stateSetup}
@@ -91,12 +90,13 @@ in {
           StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
         };
       };
-    }
-    else {
-      # User LaunchAgent mode (original behavior).
-      # Uses `script` (not `command`) for wait4path /nix/store guard,
-      # which prevents silent failures if the Nix volume is not yet
-      # mounted when launchd loads the agent at boot.
+    })
+
+    # User LaunchAgent mode (original behavior).
+    # Uses `script` (not `command`) for wait4path /nix/store guard,
+    # which prevents silent failures if the Nix volume is not yet
+    # mounted when launchd loads the agent at boot.
+    (mkIf (cfg.user == null) {
       launchd.user.agents.imessage-bridge = {
         script = bridgeCmd;
         serviceConfig =
@@ -109,6 +109,6 @@ in {
             StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
           };
       };
-    }
-  );
+    })
+  ]);
 }

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -15,14 +15,29 @@ with lib; let
 
   bridgeCmd = lib.escapeShellArgs bridgeArgs;
 
+  # Effective log directory: explicit cfg.logDir, or /var/log/imessage-bridge
+  # for daemon mode. Null means no log capture (user agent default).
+  effectiveLogDir =
+    if cfg.logDir != null
+    then cfg.logDir
+    else if cfg.user != null
+    then "/var/log/imessage-bridge"
+    else null;
+
   # State setup for system daemon mode: create log directory.
   # Runs inside daemon script rather than system.activationScripts because
   # nix-darwin did not reliably include custom activation scripts in the
   # generated system activation profile for some configurations.
   # install -d is fully idempotent.
-  stateSetup = ''
-    install -d -o root -g wheel ${escapeShellArg cfg.logDir}
+  stateSetup = lib.optionalString (effectiveLogDir != null) ''
+    install -d -o root -g wheel ${escapeShellArg effectiveLogDir}
   '';
+
+  logPaths =
+    lib.optionalAttrs (effectiveLogDir != null) {
+      StandardOutPath = "${effectiveLogDir}/imessage-bridge.log";
+      StandardErrorPath = "${effectiveLogDir}/imessage-bridge.err.log";
+    };
 in {
   options.services.imessage-bridge = {
     enable = mkEnableOption "iMessage Bridge HTTP server";
@@ -66,16 +81,14 @@ in {
     };
 
     logDir = mkOption {
-      type = types.path;
-      default =
-        if cfg.user != null
-        then "/var/log/imessage-bridge"
-        else throw "services.imessage-bridge.logDir must be set when user is null (user agent mode)";
-      defaultText = literalExpression ''
-        "/var/log/imessage-bridge" when user is set;
-        must be explicitly set in user agent mode
+      type = types.nullOr types.path;
+      default = null;
+      defaultText = literalExpression "null (no log capture in user agent mode; /var/log/imessage-bridge in daemon mode)";
+      description = ''
+        Directory for StandardOutPath and StandardErrorPath logs.
+        When null in user agent mode, launchd captures no log output.
+        When user is set (daemon mode), defaults to /var/log/imessage-bridge.
       '';
-      description = "Directory for StandardOutPath and StandardErrorPath logs.";
     };
   };
 
@@ -90,12 +103,12 @@ in {
           ${stateSetup}
           exec su -m ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
         '';
-        serviceConfig = {
-          RunAtLoad = true;
-          KeepAlive = true;
-          StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
-          StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
-        };
+        serviceConfig =
+          {
+            RunAtLoad = true;
+            KeepAlive = true;
+          }
+          // logPaths;
       };
     })
 
@@ -106,12 +119,12 @@ in {
     (mkIf (cfg.user == null) {
       launchd.user.agents.imessage-bridge = {
         script = bridgeCmd;
-        serviceConfig = {
-          RunAtLoad = true;
-          KeepAlive = true;
-          StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
-          StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
-        };
+        serviceConfig =
+          {
+            RunAtLoad = true;
+            KeepAlive = true;
+          }
+          // logPaths;
       };
     })
   ]);

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -6,6 +6,23 @@
 }:
 with lib; let
   cfg = config.services.imessage-bridge;
+
+  bridgeArgs =
+    [(lib.getExe cfg.package)]
+    ++ ["--port" (toString cfg.port)]
+    ++ lib.optionals (cfg.bonjourName != null) ["--name" cfg.bonjourName]
+    ++ lib.optional cfg.noBonjour "--no-bonjour";
+
+  bridgeCmd = lib.escapeShellArgs bridgeArgs;
+
+  # State setup for system daemon mode: create log directory.
+  # Runs inside daemon script rather than system.activationScripts because
+  # nix-darwin did not reliably include custom activation scripts in the
+  # generated system activation profile for some configurations.
+  # install -d is fully idempotent.
+  stateSetup = ''
+    install -d -o root -g wheel '${cfg.logDir}'
+  '';
 in {
   options.services.imessage-bridge = {
     enable = mkEnableOption "iMessage Bridge HTTP server";
@@ -35,31 +52,63 @@ in {
       description = "Disable Bonjour/mDNS service registration.";
     };
 
-    logDir = mkOption {
-      type = types.nullOr types.path;
+    user = mkOption {
+      type = types.nullOr types.str;
       default = null;
-      description = "Directory for StandardOutPath and StandardErrorPath logs. When null, launchd defaults apply.";
+      description = ''
+        System user to run the bridge as. When set, the module creates a
+        system LaunchDaemon instead of a user LaunchAgent. The daemon runs
+        as root for directory setup, then drops to this user via su.
+        The user must have an active macOS GUI session with Messages.app
+        signed in, and Full Disk Access granted to the nix-wrapped python
+        binary.
+      '';
+    };
+
+    logDir = mkOption {
+      type = types.path;
+      default = "/var/log/imessage-bridge";
+      description = "Directory for StandardOutPath and StandardErrorPath logs.";
     };
   };
 
-  config = mkIf cfg.enable {
-    launchd.user.agents.imessage-bridge = {
-      command = lib.escapeShellArgs (
-        [(lib.getExe cfg.package)]
-        ++ ["--port" (toString cfg.port)]
-        ++ lib.optionals (cfg.bonjourName != null) ["--name" cfg.bonjourName]
-        ++ lib.optional cfg.noBonjour "--no-bonjour"
-      );
-
-      serviceConfig =
-        {
+  config = mkIf cfg.enable (
+    if cfg.user != null
+    then {
+      # System LaunchDaemon mode (PR 513 pattern).
+      # Runs as root for state setup, drops to cfg.user for bridge execution.
+      # Uses `script` (not `command`) so nix-darwin generates a wait4path
+      # guard for the Nix store volume.
+      launchd.daemons.imessage-bridge = {
+        script = ''
+          ${stateSetup}
+          exec su -m ${cfg.user} -c ${escapeShellArg bridgeCmd}
+        '';
+        serviceConfig = {
           RunAtLoad = true;
           KeepAlive = true;
-        }
-        // lib.optionalAttrs (cfg.logDir != null) {
           StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
           StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
         };
-    };
-  };
+      };
+    }
+    else {
+      # User LaunchAgent mode (original behavior).
+      # Uses `script` (not `command`) for wait4path /nix/store guard,
+      # which prevents silent failures if the Nix volume is not yet
+      # mounted when launchd loads the agent at boot.
+      launchd.user.agents.imessage-bridge = {
+        script = bridgeCmd;
+        serviceConfig =
+          {
+            RunAtLoad = true;
+            KeepAlive = true;
+          }
+          // lib.optionalAttrs (cfg.logDir != "/var/log/imessage-bridge") {
+            StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
+            StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
+          };
+      };
+    }
+  );
 }

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -23,6 +23,14 @@ with lib; let
   stateSetup = ''
     install -d -o root -g wheel '${cfg.logDir}'
   '';
+
+  # Default log directory depends on the mode:
+  #   system daemon -> /var/log/imessage-bridge (root-owned, stateSetup creates it)
+  #   user agent   -> ~/Library/Logs (user-writable, no setup needed)
+  defaultLogDir =
+    if cfg.user != null
+    then "/var/log/imessage-bridge"
+    else "/Users/${cfg.user or "jack"}/Library/Logs";
 in {
   options.services.imessage-bridge = {
     enable = mkEnableOption "iMessage Bridge HTTP server";
@@ -67,7 +75,11 @@ in {
 
     logDir = mkOption {
       type = types.path;
-      default = "/var/log/imessage-bridge";
+      default = defaultLogDir;
+      defaultText = literalExpression ''
+        if cfg.user != null then "/var/log/imessage-bridge"
+        else "/Users/''${cfg.user or "jack"}/Library/Logs"
+      '';
       description = "Directory for StandardOutPath and StandardErrorPath logs.";
     };
   };
@@ -81,7 +93,7 @@ in {
       launchd.daemons.imessage-bridge = {
         script = ''
           ${stateSetup}
-          exec su -m ${cfg.user} -c ${escapeShellArg bridgeCmd}
+          exec su -m ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
         '';
         serviceConfig = {
           RunAtLoad = true;
@@ -99,15 +111,12 @@ in {
     (mkIf (cfg.user == null) {
       launchd.user.agents.imessage-bridge = {
         script = bridgeCmd;
-        serviceConfig =
-          {
-            RunAtLoad = true;
-            KeepAlive = true;
-          }
-          // lib.optionalAttrs (cfg.logDir != "/var/log/imessage-bridge") {
-            StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
-            StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
-          };
+        serviceConfig = {
+          RunAtLoad = true;
+          KeepAlive = true;
+          StandardOutPath = "${cfg.logDir}/imessage-bridge.log";
+          StandardErrorPath = "${cfg.logDir}/imessage-bridge.err.log";
+        };
       };
     })
   ]);

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -13,7 +13,7 @@ with lib; let
     ++ lib.optionals (cfg.bonjourName != null) ["--name" cfg.bonjourName]
     ++ lib.optional cfg.noBonjour "--no-bonjour";
 
-  bridgeCmd = lib.escapeShellArgs bridgeArgs;
+  bridgeCmd = "exec " + lib.escapeShellArgs bridgeArgs;
 
   # Effective log directory: explicit cfg.logDir, or /var/log/imessage-bridge
   # for daemon mode. Null means no log capture (user agent default).
@@ -33,10 +33,9 @@ with lib; let
     install -d -o root -g wheel ${escapeShellArg (toString effectiveLogDir)}
   '';
 
-  logPaths =
-    lib.optionalAttrs (effectiveLogDir != null) {
-      StandardOutPath = "${effectiveLogDir}/imessage-bridge.log";
-      StandardErrorPath = "${effectiveLogDir}/imessage-bridge.err.log";
+  logPaths = lib.optionalAttrs (effectiveLogDir != null) {
+    StandardOutPath = "${toString effectiveLogDir}/imessage-bridge.log";
+    StandardErrorPath = "${toString effectiveLogDir}/imessage-bridge.err.log";
     };
 
   # Wrapper script for system daemon mode: sets HOME to the target user's

--- a/modules/nix-darwin/imessage-bridge.nix
+++ b/modules/nix-darwin/imessage-bridge.nix
@@ -13,7 +13,7 @@ with lib; let
     ++ lib.optionals (cfg.bonjourName != null) ["--name" cfg.bonjourName]
     ++ lib.optional cfg.noBonjour "--no-bonjour";
 
-  bridgeCmd = "exec " + lib.escapeShellArgs bridgeArgs;
+  bridgeCmd = lib.escapeShellArgs bridgeArgs;
 
   # Effective log directory: explicit cfg.logDir, or /var/log/imessage-bridge
   # for daemon mode. Null means no log capture (user agent default).
@@ -38,6 +38,16 @@ with lib; let
       StandardOutPath = "${effectiveLogDir}/imessage-bridge.log";
       StandardErrorPath = "${effectiveLogDir}/imessage-bridge.err.log";
     };
+
+  # Wrapper script for system daemon mode: sets HOME to the target user's
+  # home directory so the bridge can find ~/Library/Messages/chat.db.
+  # su -m preserves the calling environment (including Nix store PATH)
+  # rather than starting a login shell which would reset PATH and source
+  # profile scripts.
+  daemonScript = pkgs.writeShellScript "imessage-bridge-as-${cfg.user}" ''
+    export HOME=${escapeShellArg "/Users/${cfg.user}"}
+    exec ${bridgeCmd}
+  '';
 in {
   options.services.imessage-bridge = {
     enable = mkEnableOption "iMessage Bridge HTTP server";
@@ -101,7 +111,7 @@ in {
       launchd.daemons.imessage-bridge = {
         script = ''
           ${stateSetup}
-          exec su -l ${escapeShellArg cfg.user} -c ${escapeShellArg bridgeCmd}
+          exec /usr/bin/su -m ${escapeShellArg cfg.user} -c ${escapeShellArg daemonScript}
         '';
         serviceConfig =
           {


### PR DESCRIPTION
## Summary

Add a `user` option to the imessage-bridge nix-darwin module that switches from a user LaunchAgent to a system LaunchDaemon, following the PR 513 (Ollama) pattern.

When `user` is set (e.g. `"plato"`):
- Generates `launchd.daemons` instead of `launchd.user.agents`
- Startup script creates log directory, then drops privileges via `su -m $user`
- Migrated from `command` to `script` for the `wait4path /nix/store` boot guard

When `user` is `null` (default):
- Preserves original `launchd.user.agents` behavior — no breaking change

## Changes

- New option: `services.imessage-bridge.user` (nullOr str, default null)
- New option: `services.imessage-bridge.logDir` (str, default depends on mode)
- `mkMerge`/`mkIf` to avoid infinite recursion in the Nix module config block
- `command` -> `script` migration for boot-time path resolution
- `stateSetup` creates log dir before launch

## Testing

- `nix eval` confirms module loads without errors
- Garden PR 501 consumes this branch and validates the generated LaunchDaemon:
  ```
  script: "install -d -o root -g wheel /var/log/imessage-bridge\n\nexec su -m plato -c ..."
  StandardOutPath: /var/log/imessage-bridge/imessage-bridge.log
  StandardErrorPath: /var/log/imessage-bridge/imessage-bridge.err.log
  ```
- No user agent generated when `user` is set (confirmed via `nix eval`)

## Context

- Garden PR: jmmaloney4/garden#501
- Pattern reference: jmmaloney4/garden#513 (Ollama daemon on hermione)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes launchd orchestration (agent vs daemon), adds root-run startup steps and privilege dropping via `su`, and changes logging behavior defaults depending on configuration.
> 
> **Overview**
> Adds a new `services.imessage-bridge.user` option that switches the service from a per-user `launchd` LaunchAgent to a system LaunchDaemon, performing log directory setup as root and then running the bridge under the specified user via `su` (with `HOME` set).
> 
> Refactors launchd generation to use `script` (instead of `command`) in both modes to get nix-darwin’s `/nix/store` wait4path guard, and updates `logDir` handling so log capture is disabled by default for agent mode but defaults to `/var/log/imessage-bridge` in daemon mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9463c8b825674cdde30b9d5432d660454835b05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->