### PR TITLE
feat(checks): add typeChecker option to migrate mypy to ty

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ in {
     - nix: `just build-all`, `just build-all-verbose` (flake-iter)
     - nodejs: `just update-pnpm-hash` (refresh `pnpm-lock.yaml` and rewrite `pnpmDepsHash` in `flake.nix`), `just update-pnpm-deps` (alias)
   - Options under `jackpkgs.just` to replace tool packages used by generated `just` recipes:
-    - `biomePackage`, `direnvPackage`, `fdPackage`, `flakeIterPackage`, `googleCloudSdkPackage`, `jqPackage`, `mypyPackage`, `nbstripoutPackage`, `preCommitPackage`, `pulumiPackage`, `ruffPackage`
+    - `biomePackage`, `direnvPackage`, `fdPackage`, `flakeIterPackage`, `googleCloudSdkPackage`, `jqPackage`, `mypyPackage`, `nbstripoutPackage`, `preCommitPackage`, `pulumiPackage`, `ruffPackage`, `tyPackage`
     - `mypyPackage` defaults to the dev-tools Python environment used by `checks` / `pre-commit`
+    - `tyPackage` defaults to `pkgs.ty` (nixpkgs); used when `typeChecker = "ty"`
     - `ruffPackage` defaults to the same dev-tools Python environment as `mypyPackage`
     - `pulumiBackendUrl` (nullable string)
   - Options under `jackpkgs.gcp`:
@@ -197,6 +198,7 @@ in {
     - `treefmtPackage` (defaults to `config.treefmt.build.wrapper`)
     - `nbstripoutPackage` (default `config.jackpkgs.pkgs.nbstripout`)
     - `python.mypy.package` (dev-tools env selection: prefers non-editable env with `includeGroups = true`; falls back to `pythonDefaultEnv`, then `pkgs.mypy`)
+    - `python.mypy.tyPackage` (defaults to `pkgs.ty`; used when `typeChecker = "ty"`)
     - `python.ruff.package`, `python.pytest.package`, `python.numpydoc.package` (each defaults to `python.mypy.package`)
     - `typescript.tsc.package` (defaults to `pkgs.nodePackages.typescript`)
     - `typescript.tsc.nodeModules` (nullable package, default `null` -> falls back to `jackpkgs.outputs.nodeModules`)
@@ -217,7 +219,7 @@ in {
   - Options under `jackpkgs.checks`:
     - `enable` (bool, default auto-enabled when `jackpkgs.python.enable` or `jackpkgs.nodejs.enable`)
     - `python.enable` (bool, default `jackpkgs.python.enable`)
-    - `python.mypy.enable` (bool, default `true`), `python.mypy.extraArgs` (list, default `[]`)
+    - `python.mypy.enable` (bool, default `true`), `python.mypy.typeChecker` (enum `"mypy"` (default, deprecated) | `"ty"`), `python.mypy.extraArgs` (list, default `[]`)
     - `python.ruff.enable` (bool, default `true`), `python.ruff.extraArgs` (list, default `["--no-cache"]`)
     - `python.pytest.enable` (bool, default `true`), `python.pytest.extraArgs` (list, default `["--import-mode=importlib"]`)
     - `python.numpydoc.enable` (bool, **default `false`** - explicit opt-in), `python.numpydoc.extraArgs` (list, default `[]`)
@@ -230,6 +232,9 @@ in {
 ```nix
 # Disable mypy in both CI checks and pre-commit hook:
 jackpkgs.checks.python.mypy.enable = false;
+
+# Migrate from mypy to ty (Astral's fast Rust-based type checker):
+jackpkgs.checks.python.mypy.typeChecker = "ty";
 
 # Enable numpydoc in both surfaces (opt-in):
 jackpkgs.checks.python.numpydoc.enable = true;

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -57,13 +57,29 @@ in {
           enable = mkOption {
             type = types.bool;
             default = true;
-            description = "Enable mypy type checking";
+            description = "Enable Python type checking";
+          };
+
+          typeChecker = mkOption {
+            type = types.enum ["mypy" "ty"];
+            default = "mypy";
+            description = ''
+              Python type checker to use.
+
+              - `"mypy"` (default, **deprecated**): Uses mypy. Will be removed in a
+                future release. Migrate to `"ty"` when ready.
+              - `"ty"`: Uses [ty](https://github.com/astral-sh/ty), Astral's fast
+                Rust-based type checker. Drop-in replacement that respects
+                `# type: ignore` comments.
+
+              Migration: set `jackpkgs.checks.python.mypy.typeChecker = "ty"`.
+            '';
           };
 
           extraArgs = mkOption {
             type = types.listOf types.str;
             default = [];
-            description = "Extra arguments to pass to mypy";
+            description = "Extra arguments to pass to the type checker";
             example = ["--strict"];
           };
         };
@@ -508,20 +524,32 @@ in {
             };
           }
           // lib.optionalAttrs cfg.python.mypy.enable {
-            # mypy check (workspace root)
-            mypy = mkCheck {
-              name = "mypy";
-              src = pythonCfg.workspaceRoot;
-              buildInputs = [pythonEnvWithDevTools];
-              setupCommands = ''
-                export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
-                export MYPY_CACHE_DIR=$TMPDIR/.mypy_cache
-              '';
-              checkCommands = ''
-                echo "Running mypy (workspace root)..."
-                mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
-              '';
-            };
+            # Python type-check (workspace root)
+            mypy =
+              if cfg.python.mypy.typeChecker == "ty"
+              then mkCheck {
+                name = "mypy";
+                src = pythonCfg.workspaceRoot;
+                buildInputs = [pythonEnvWithDevTools config.jackpkgs.pkgs.ty];
+                checkCommands = ''
+                  echo "Running ty check (workspace root)..."
+                  ty check --python ${pythonEnvWithDevTools}${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
+                '';
+              }
+              else mkCheck {
+                name = "mypy";
+                src = pythonCfg.workspaceRoot;
+                buildInputs = [pythonEnvWithDevTools];
+                setupCommands = ''
+                  export PYTHONPATH="${pythonEnvWithDevTools}/lib/python${pythonVersion}/site-packages"
+                  export MYPY_CACHE_DIR=$TMPDIR/.mypy_cache
+                '';
+                checkCommands = ''
+                  echo 'WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = "ty"' >&2
+                  echo "Running mypy (workspace root)..."
+                  mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
+                '';
+              };
           }
           // lib.optionalAttrs cfg.python.ruff.enable {
             # ruff check (workspace root)

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -504,6 +504,9 @@ in {
       # ============================================================
 
       pythonChecks =
+        let
+          mypyDeprecationWarning = ''echo 'WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = "ty"' >&2'';
+        in
         lib.optionalAttrs (cfg.enable && cfg.python.enable && pythonEnvWithDevTools != null && pythonWorkspaceMembers != [])
         (
           lib.optionalAttrs cfg.python.pytest.enable {
@@ -533,7 +536,7 @@ in {
                 buildInputs = [pythonEnvWithDevTools config.jackpkgs.pkgs.ty];
                 checkCommands = ''
                   echo "Running ty check (workspace root)..."
-                  ty check --python ${pythonEnvWithDevTools}${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
+                  ty check --python ${pythonEnvWithDevTools} ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
                 '';
               }
               else mkCheck {
@@ -545,7 +548,7 @@ in {
                   export MYPY_CACHE_DIR=$TMPDIR/.mypy_cache
                 '';
                 checkCommands = ''
-                  echo 'WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = "ty"' >&2
+                  ${mypyDeprecationWarning}
                   echo "Running mypy (workspace root)..."
                   mypy ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .
                 '';

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -76,6 +76,16 @@ in {
             '';
           };
 
+          tyPackage = mkOption {
+            type = types.package;
+            default = config.jackpkgs.pkgs.ty;
+            defaultText = "config.jackpkgs.pkgs.ty";
+            description = ''
+              `ty` binary package to use when `typeChecker = "ty"`.
+              Defaults to `config.jackpkgs.pkgs.ty` (nixpkgs).
+            '';
+          };
+
           extraArgs = mkOption {
             type = types.listOf types.str;
             default = [];
@@ -533,7 +543,7 @@ in {
               then mkCheck {
                 name = "mypy";
                 src = pythonCfg.workspaceRoot;
-                buildInputs = [pythonEnvWithDevTools config.jackpkgs.pkgs.ty];
+                buildInputs = [pythonEnvWithDevTools cfg.python.mypy.tyPackage];
                 checkCommands = ''
                   echo "Running ty check (workspace root)..."
                   ty check --python ${pythonEnvWithDevTools} ${lib.escapeShellArgs cfg.python.mypy.extraArgs} .

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -490,6 +490,7 @@ in {
                         "# mypy (Python type checker) [deprecated: migrate to ty]"
                         "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                         "  printf '%s\\n' \"==> mypy\""
+                        "  echo 'WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = \"ty\"' >&2"
                         ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} ${extraArgs} .''
                         "fi"
                       ]

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -474,6 +474,7 @@ in {
                   ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.mypy.enable) (
                     let
                       typeChecker = checksCfgForRecipes.python.mypy.typeChecker or "mypy";
+                      extraArgs = lib.escapeShellArgs checksCfgForRecipes.python.mypy.extraArgs;
                     in
                       if typeChecker == "ty"
                       then [
@@ -481,7 +482,7 @@ in {
                         "# ty (Python type checker)"
                         "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                         "  printf '%s\\n' \"==> ty check\""
-                        "  ${lib.getExe sysCfg.tyPackage} check --python ${sysCfg.mypyPackage} ."
+                        "  ${lib.getExe sysCfg.tyPackage} check --python ${sysCfg.mypyPackage} ${extraArgs} ."
                         "fi"
                       ]
                       else [
@@ -489,7 +490,7 @@ in {
                         "# mypy (Python type checker) [deprecated: migrate to ty]"
                         "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
                         "  printf '%s\\n' \"==> mypy\""
-                        ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} .''
+                        ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} ${extraArgs} .''
                         "fi"
                       ]
                   ))

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -120,6 +120,16 @@ in {
             `just lint` Python type-check step.
           '';
         };
+        tyPackage = mkOption {
+          type = types.package;
+          default = config.jackpkgs.pkgs.ty;
+          defaultText = "config.jackpkgs.pkgs.ty";
+          description = ''
+            `ty` binary package to use when
+            `jackpkgs.checks.python.mypy.typeChecker = "ty"`.
+            Defaults to `config.jackpkgs.pkgs.ty` (nixpkgs).
+          '';
+        };
         biomePackage = mkOption {
           type = types.package;
           default = config.jackpkgs.pkgs.biome;
@@ -461,14 +471,28 @@ in {
                     "  fi"
                     "fi"
                   ])
-                  ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.mypy.enable) [
-                    ""
-                    "# mypy (Python type checker)"
-                    "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
-                    "  printf '%s\\n' \"==> mypy\""
-                    ''${lib.getExe' sysCfg.mypyPackage "mypy"} .''
-                    "fi"
-                  ])
+                  ++ (optionalLines (checksOptionsDefined && checksCfgForRecipes.python.mypy.enable) (
+                    let
+                      typeChecker = checksCfgForRecipes.python.mypy.typeChecker or "mypy";
+                    in
+                      if typeChecker == "ty"
+                      then [
+                        ""
+                        "# ty (Python type checker)"
+                        "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
+                        "  printf '%s\\n' \"==> ty check\""
+                        "  ${lib.getExe sysCfg.tyPackage} check --python ${sysCfg.mypyPackage} ."
+                        "fi"
+                      ]
+                      else [
+                        ""
+                        "# mypy (Python type checker) [deprecated: migrate to ty]"
+                        "if ${lib.getExe sysCfg.fdPackage} -q -e py -e pyi; then"
+                        "  printf '%s\\n' \"==> mypy\""
+                        ''  ${lib.getExe' sysCfg.mypyPackage "mypy"} .''
+                        "fi"
+                      ]
+                  ))
                   ++ (optionalLines (checksOptionsDefined && lib.attrByPath ["biome" "lint" "enable"] false checksCfgForRecipes) [
                     ""
                     "# biome (JS/TS linter)"

--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -13,6 +13,7 @@
   jackpkgsPythonCfg = config.jackpkgs.python or {};
   checksOptionsDefined = lib.hasAttrByPath ["jackpkgs" "checks"] options;
   checksCfg = lib.attrByPath ["jackpkgs" "checks"] {} config;
+  mypyDeprecationWarning = ''echo 'WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = "ty"' >&2'';
 in {
   imports = [
     jackpkgsInputs.pre-commit-hooks.flakeModule
@@ -492,7 +493,7 @@ in {
                       or (lib.versions.majorMinor jackpkgsPythonCfg.pythonPackage.version or "3.12")
                   else "3.12";
               in "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
-                echo "WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = \"ty\"" >&2
+                ${mypyDeprecationWarning}
                 export PYTHONPATH="${mypyPkg}/lib/python${pythonVersion}/site-packages"
                 export MYPY_CACHE_DIR="''${TMPDIR:-/tmp}/.mypy_cache"
                 ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .

--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -69,6 +69,16 @@ in {
                 with dependency groups enabled.
               '';
             };
+
+            tyPackage = mkOption {
+              type = types.package;
+              default = config.jackpkgs.pkgs.ty;
+              defaultText = "config.jackpkgs.pkgs.ty";
+              description = ''
+                `ty` binary package to use when `jackpkgs.checks.python.mypy.typeChecker = "ty"`.
+                Defaults to `config.jackpkgs.pkgs.ty` (nixpkgs).
+              '';
+            };
           };
 
           ruff = {
@@ -452,29 +462,41 @@ in {
 
           settings.hooks.mypy = {
             enable = checksCfg.python.mypy.enable;
-            package = sysCfg.python.mypy.package;
-            # Run mypy on the whole workspace (same scope as `just lint` /
-            # CI checks) instead of per-staged-file.  When pass_filenames is
-            # true (the default) pre-commit passes only the staged file
-            # paths, mypy can't resolve the full type graph, and valid
-            # `# type: ignore` directives get flagged as "unused".
+            package =
+              if checksCfg.python.mypy.typeChecker == "ty"
+              then sysCfg.python.mypy.tyPackage
+              else sysCfg.python.mypy.package;
+            # Run the type checker on the whole workspace (same scope as
+            # `just lint` / CI checks) instead of per-staged-file.  When
+            # pass_filenames is true (the default) pre-commit passes only
+            # the staged file paths, and per-file analysis can't resolve the
+            # full type graph.
             pass_filenames = false;
-            entry = let
-              mypyPkg = sysCfg.python.mypy.package;
-              # Resolve the Python interpreter version the same way
-              # checks.nix does (from jackpkgs.python.pythonPackage, not
-              # from the mypy tool package whose .version is the mypy
-              # version, not the Python version).
-              pythonVersion =
-                if jackpkgsPythonCfg ? pythonPackage && jackpkgsPythonCfg.pythonPackage != null
-                then jackpkgsPythonCfg.pythonPackage.pythonVersion
-                    or (lib.versions.majorMinor jackpkgsPythonCfg.pythonPackage.version or "3.12")
-                else "3.12";
-            in "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
-              export PYTHONPATH="${mypyPkg}/lib/python${pythonVersion}/site-packages"
-              export MYPY_CACHE_DIR="''${TMPDIR:-/tmp}/.mypy_cache"
-              ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .
-            ''}";
+            entry =
+              if checksCfg.python.mypy.typeChecker == "ty"
+              then let
+                mypyPkg = sysCfg.python.mypy.package;
+                tyBin = lib.getExe sysCfg.python.mypy.tyPackage;
+              in "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
+                ${tyBin} check --python ${mypyPkg}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .
+              ''}"
+              else let
+                mypyPkg = sysCfg.python.mypy.package;
+                # Resolve the Python interpreter version the same way
+                # checks.nix does (from jackpkgs.python.pythonPackage, not
+                # from the mypy tool package whose .version is the mypy
+                # version, not the Python version).
+                pythonVersion =
+                  if jackpkgsPythonCfg ? pythonPackage && jackpkgsPythonCfg.pythonPackage != null
+                  then jackpkgsPythonCfg.pythonPackage.pythonVersion
+                      or (lib.versions.majorMinor jackpkgsPythonCfg.pythonPackage.version or "3.12")
+                  else "3.12";
+              in "${lib.getExe pkgs.bash} -euo pipefail -c ${lib.escapeShellArg ''
+                echo "WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = \"ty\"" >&2
+                export PYTHONPATH="${mypyPkg}/lib/python${pythonVersion}/site-packages"
+                export MYPY_CACHE_DIR="''${TMPDIR:-/tmp}/.mypy_cache"
+                ${lib.getExe' mypyPkg "mypy"}${escapeExtraArgs checksCfg.python.mypy.extraArgs} .
+              ''}";
             files = "\\.py$";
             excludes = defaultExcludes.preCommit;
           };

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -340,6 +340,46 @@ in {
     expected = true;
   };
 
+  testPythonTyCheckScript = let
+    checks = mkChecks {
+      configModule = mkConfigModule {
+        pythonEnable = true;
+        extraConfig.jackpkgs.checks.python.mypy.typeChecker = "ty";
+      };
+    };
+    script = getBuildCommand checks.mypy;
+  in {
+    expr =
+      hasInfixAll ["Running ty check (workspace root)..." ''cd "$src"'' "ty check" "--python"] script
+      && !lib.hasInfix "mypy" (lib.removePrefix "Running ty check" script);
+    expected = true;
+  };
+
+  testPythonTyCheckNoPythonpath = let
+    checks = mkChecks {
+      configModule = mkConfigModule {
+        pythonEnable = true;
+        extraConfig.jackpkgs.checks.python.mypy.typeChecker = "ty";
+      };
+    };
+    script = getBuildCommand checks.mypy;
+  in {
+    # ty is a standalone Rust binary - it should NOT set PYTHONPATH
+    expr = !lib.hasInfix "PYTHONPATH=" script;
+    expected = true;
+  };
+
+  testPythonMypyDefaultDeprecationWarning = let
+    checks = mkChecks {
+      configModule = mkConfigModule {pythonEnable = true;};
+    };
+    script = getBuildCommand checks.mypy;
+  in {
+    # Default mypy path should emit a deprecation warning
+    expr = lib.hasInfix "mypy is deprecated" script;
+    expected = true;
+  };
+
   testPythonRuffScript = let
     checks = mkChecks {
       configModule = mkConfigModule {

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -351,7 +351,7 @@ in {
   in {
     expr =
       hasInfixAll ["Running ty check (workspace root)..." ''cd "$src"'' "ty check" "--python"] script
-      && !lib.hasInfix "mypy" (lib.removePrefix "Running ty check" script);
+      && !lib.hasInfix "mypy " script;
     expected = true;
   };
 


### PR DESCRIPTION
## Summary

Add a `typeChecker` enum option under `jackpkgs.checks.python.mypy` that lets users migrate from mypy to [ty](https://github.com/astral-sh/ty) — Astral's fast Rust-based Python type checker.

## New option

```nix
jackpkgs.checks.python.mypy.typeChecker = "ty";  # or "mypy" (default, deprecated)
```

This single option switches the type checker across **all three surfaces**:
1. **CI checks** (`nix flake check`) — `ty check --python <env>` instead of `mypy`
2. **Pre-commit hooks** — hook package and entry point switch to ty
3. **`just lint` recipes** — mypy section becomes ty section

## Backwards compatibility

- **Default is still `"mypy"`** — no behavior change for existing users
- When `"mypy"` is active, a deprecation warning is printed to stderr:
  ```
  WARNING: mypy is deprecated. Migrate to ty: jackpkgs.checks.python.mypy.typeChecker = "ty"
  ```
- Users opt into ty explicitly by setting `typeChecker = "ty"`

## New package options

- `jackpkgs.pre-commit.python.mypy.tyPackage` (defaults to `pkgs.ty`)
- `jackpkgs.just.tyPackage` (defaults to `pkgs.ty`)

## Tests

Added 3 new nix-unit tests:
- `testPythonTyCheckScript` — verifies ty invocation with `--python` flag
- `testPythonTyCheckNoPythonpath` — verifies ty does NOT set PYTHONPATH (standalone Rust binary)
- `testPythonMypyDefaultDeprecationWarning` — verifies default path emits deprecation warning

All 145/145 tests pass on `aarch64-darwin`.

## Files changed

| File | Change |
|------|--------|
| `modules/flake-parts/checks.nix` | Add `typeChecker` option, branch mypy check |
| `modules/flake-parts/pre-commit.nix` | Add `tyPackage` option, branch hook |
| `modules/flake-parts/just.nix` | Add `tyPackage` option, branch lint recipe |
| `tests/checks.nix` | Add 3 ty-related tests |
| `README.md` | Document `typeChecker`, `tyPackage`, migration example |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how Python type checking is executed across CI checks, pre-commit, and `just lint`, which can affect developer workflows and CI outcomes. Default remains `mypy`, but opting into `ty` introduces new tool/package wiring that may vary by environment.
> 
> **Overview**
> Adds a `jackpkgs.checks.python.mypy.typeChecker` enum (`"mypy"` *deprecated* | `"ty"`) to switch Python type checking to Astral’s `ty` across **CI checks**, **pre-commit**, and **`just lint`**.
> 
> Introduces `tyPackage` override options (checks/pre-commit/just), updates the generated commands to run `ty check --python <env>` when selected, and emits a stderr deprecation warning when using `mypy`.
> 
> Extends nix-unit tests to cover `ty` invocation behavior and the new deprecation warning, and updates README docs with the new options and migration example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48859729815673abfa21bdcf3d56dc61a2bf1ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->