### PR TITLE
chore: update workflow refs for toolbox → sector7 rename

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-	"extends": ["github>jmmaloney4/toolbox//renovate/all.json"]
+	"extends": ["github>jmmaloney4/sector7//renovate/all.json"]
 }

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,4 +8,4 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/toolbox/.github/workflows/adr-management.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
        !contains(github.event.comment.body, 'no claude review') &&
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
-    uses: jmmaloney4/toolbox/.github/workflows/claude-review.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/toolbox/.github/workflows/claude.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@e6f08de5f5b16fd7c44101c3c0f1df72fb6e450d # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}


### PR DESCRIPTION
The repo jmmaloney4/toolbox has been renamed to jmmaloney4/sector7. GitHub Actions `uses:` refs do NOT follow redirects, so all workflow references to the old name 404.

This PR updates all 6 references:

- .github/workflows/nix.yml
- .github/workflows/claude-review.yml
- .github/workflows/claude.yml
- .github/workflows/add-to-project.yml
- .github/workflows/adr-management.yml
- .github/renovate.json

Replacement: `jmmaloney4/toolbox` → `jmmaloney4/sector7`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates GitHub Actions and Renovate configuration references to a renamed external repo; the main risk is CI/automation breaking if the new refs or pins are incorrect.
> 
> **Overview**
> Updates CI and automation configuration to follow the `jmmaloney4/toolbox` → `jmmaloney4/sector7` repo rename.
> 
> All reusable workflow `uses:` references (Nix, Claude, ADR management, add-to-project) and Renovate `extends` are switched to the new repository path while keeping the same pinned commit SHAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6800e127459b790a095d7ea74a471b391d55863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->