### PR TITLE
feat: add container.nix flake-parts module for nix2container image building

### DIFF
--- a/docs/internal/designs/030-container-image-flake-module.md
+++ b/docs/internal/designs/030-container-image-flake-module.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/flake.lock
+++ b/flake.lock
@@ -225,6 +225,26 @@
         "type": "github"
       }
     },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774745961,
@@ -324,6 +344,7 @@
         "home-manager": "home-manager",
         "just-flake": "just-flake",
         "nix-unit": "nix-unit",
+        "nix2container": "nix2container",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
         "pyproject-build-systems": "pyproject-build-systems",

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,10 @@
       inputs.flake-parts.follows = "flake-parts";
       inputs.treefmt-nix.follows = "treefmt";
     };
+    nix2container = {
+      url = "github:nlewo/nix2container";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/flake-parts/all.nix
+++ b/modules/flake-parts/all.nix
@@ -13,5 +13,6 @@
     (import ./pulumi.nix {inherit jackpkgsInputs;})
     (import ./quarto.nix {inherit jackpkgsInputs;})
     (import ./checks.nix {inherit jackpkgsInputs;})
+    (import ./container.nix {inherit jackpkgsInputs;})
   ];
 }

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -186,7 +186,9 @@ in {
       credsExpr =
         if cfg.authMode == "gcp"
         then "\"oauth2accesstoken:$(gcloud auth print-access-token)\""
-        else "\"\${GITHUB_ACTOR}:\${GITHUB_TOKEN}\"";
+        else if cfg.authMode == "ghcr"
+        then "\"\${GITHUB_ACTOR}:\${GITHUB_TOKEN}\""
+        else abort "jackpkgs.images: unsupported authMode '${cfg.authMode}'";
 
       imageBuildRecipe = mkRecipeWithParams "image-build" [''name''] "Build a container image locally (produces ./result JSON manifest)" [
         "nix build .#images.{{name}}"
@@ -199,7 +201,7 @@ in {
         "${lib.getExe skopeoNix2container} inspect nix:./result | ${lib.getExe pkgs.jq} -r '.Digest'"
       ] false;
 
-      imagePushRecipe = mkRecipeWithParams "image-push" [''name'' ''tag=\"latest\"''] "Push a single image to its configured registry" (
+      imagePushRecipe = mkRecipeWithParams "image-push" [''name'' ''tag="latest"''] "Push a single image to its configured registry" (
         [
           "#!/usr/bin/env bash"
           "set -euo pipefail"
@@ -226,7 +228,7 @@ in {
         ]
       ) false;
 
-      imagePushAllRecipe = mkRecipeWithParams "image-push-all" [''tag=\"latest\"''] "Push all images defined in jackpkgs.images.images" (
+      imagePushAllRecipe = mkRecipeWithParams "image-push-all" [''tag="latest"''] "Push all images defined in jackpkgs.images.images" (
         [
           "#!/usr/bin/env bash"
           "set -euo pipefail"
@@ -277,9 +279,13 @@ in {
         # Fold per-image packages into layers, deduplicating against common layer
         imageLayers = foldImageLayers nix2container baseLayers imageCfg.packages;
 
-        # Inject SSL_CERT_FILE automatically
-        sslEnv = "SSL_CERT_FILE=${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-        imageEnv = imageCfg.env ++ [sslEnv];
+        # Inject SSL_CERT_FILE automatically using the consumer's cacert
+        # (from commonPackages / per-image packages), not jackpkgs' pinned nixpkgs.
+        cacertPkg = lib.findFirst (p: p.pname or "" == "cacert") null
+          (imageCfg.packages ++ linuxSysCfg.commonPackages);
+        sslEnv = lib.optional (cacertPkg != null)
+          "SSL_CERT_FILE=${cacertPkg}/etc/ssl/certs/ca-bundle.crt";
+        imageEnv = imageCfg.env ++ sslEnv;
       in
         nix2container.buildImage {
           name = imageCfg.name;

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -14,18 +14,24 @@
   # Layer deduplication helper.
   # Builds new nix2container layers for each package, threading all previously-built
   # layers through so nix2container excludes store paths already present in earlier layers.
+  # Uses prepend+reverse to maintain O(N) instead of O(N^2) with ++.
   foldImageLayers = nix2container: baseLayers: pkgList:
     let
+      # acc holds layers in reverse order; we reverse at the end.
+      # We reverse baseLayers so they also sit in the reversed accumulator.
+      init = lib.reverseList baseLayers;
       fold = acc: drv:
         let
           layer = nix2container.buildLayer {
             copyToRoot = drv;
-            layers = acc;
+            # nix2container expects layers in forward (earliest-first) order,
+            # so reverse back before passing.
+            layers = lib.reverseList acc;
           };
         in
-          acc ++ [layer];
+          [layer] ++ acc;
     in
-      lib.foldl fold baseLayers pkgList;
+      lib.reverseList (lib.foldl fold init pkgList);
 in {
   options = let
     inherit (lib) types mkOption mkEnableOption;
@@ -51,12 +57,15 @@ in {
       };
 
       authMode = mkOption {
-        type = types.enum ["gcp" "ghcr"];
+        type = types.str;
         default = "gcp";
         description = ''
           Authentication mode for `image-push` just recipe.
+          Currently supported values:
           - "gcp": uses `gcloud auth print-access-token` + oauth2accesstoken
           - "ghcr": uses `GITHUB_ACTOR` + `GITHUB_TOKEN` env vars
+          The type is `types.str` (not a fixed enum) so future auth modes
+          ("op", "raw", etc.) can be added without a module schema change.
         '';
       };
     };
@@ -84,7 +93,7 @@ in {
             options = {
               name = mkOption {
                 type = types.str;
-                default = lib.mkOptionDefault name;
+                default = name;
                 description = "Image name. Defaults to the attribute key name.";
               };
 
@@ -148,7 +157,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # Per-system config: just recipes and skopeo package
+    # Per-system config: just recipes and skopeo package — Linux-only, since
+    # nix2container and skopeo-nix2container are Linux binaries.
     perSystem = {
       pkgs,
       lib,
@@ -194,16 +204,23 @@ in {
           "#!/usr/bin/env bash"
           "set -euo pipefail"
           "nix build .#images.{{name}}"
+          "case \"{{name}}\" in"
         ]
-        ++ lib.concatMap (imgName: let
-          reg = resolveRegistry imgName;
+        ++ lib.concatMap (imgKey: let
+          imgCfg = sysCfg.images.${imgKey};
+          reg = resolveRegistry imgKey;
         in [
-          "if [ \"{{name}}\" = \"${imgName}\" ]; then"
-          "  DEST=\"${reg}/${imgName}:{{tag}}\""
-          "fi"
+          "  ${imgKey})"
+          "    DEST=\"${reg}/${imgCfg.name}:{{tag}}\""
+          "    ;;"
         ])
         imageNames
         ++ [
+          "  *)"
+          "    echo \"error: unknown image '{{name}}'\" >&2"
+          "    exit 1"
+          "    ;;"
+          "esac"
           "CREDS=${credsExpr}"
           "${lib.getExe skopeoNix2container} copy --dest-creds \"$CREDS\" nix:./result \"docker://$DEST\""
         ]
@@ -216,7 +233,7 @@ in {
         ]
         ++ map (imgName: "just image-push ${imgName} {{tag}}") imageNames
       ) false;
-    in {
+    in mkIf (system == cfg.linuxSystem) {
       # Expose skopeo-nix2container for direct use
       packages.skopeo-nix2container = skopeoNix2container;
 

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -1,0 +1,280 @@
+{jackpkgsInputs}: {
+  inputs,
+  config,
+  lib,
+  getSystem,
+  ...
+}: let
+  inherit (lib) mkIf;
+  cfg = config.jackpkgs.images;
+
+  justfileHelpers = import ../../lib/justfile-helpers.nix {inherit lib;};
+  inherit (justfileHelpers) mkRecipe mkRecipeWithParams;
+
+  # Layer deduplication helper.
+  # Builds new nix2container layers for each package, threading all previously-built
+  # layers through so nix2container excludes store paths already present in earlier layers.
+  foldImageLayers = nix2container: baseLayers: pkgList:
+    let
+      fold = acc: drv:
+        let
+          layer = nix2container.buildLayer {
+            copyToRoot = drv;
+            layers = acc;
+          };
+        in
+          acc ++ [layer];
+    in
+      lib.foldl fold baseLayers pkgList;
+in {
+  options = let
+    inherit (lib) types mkOption mkEnableOption;
+    inherit (jackpkgsInputs.flake-parts.lib) mkDeferredModuleOption;
+  in {
+    jackpkgs.images = {
+      enable = mkEnableOption "jackpkgs-images (standardized nix2container image building)" // {default = false;};
+
+      linuxSystem = mkOption {
+        type = types.str;
+        default = "x86_64-linux";
+        description = "The Linux system triple to build images for. Images are only built for this system.";
+      };
+
+      registry = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Default container registry URL (e.g. "ghcr.io/myorg/myrepo" or
+          "us-east1-docker.pkg.dev/my-project/my-repo"). Per-image `registry`
+          options override this. Required when enabled if not set per-image.
+        '';
+      };
+
+      authMode = mkOption {
+        type = types.enum ["gcp" "ghcr"];
+        default = "gcp";
+        description = ''
+          Authentication mode for `image-push` just recipe.
+          - "gcp": uses `gcloud auth print-access-token` + oauth2accesstoken
+          - "ghcr": uses `GITHUB_ACTOR` + `GITHUB_TOKEN` env vars
+        '';
+      };
+    };
+
+    perSystem = mkDeferredModuleOption ({
+      config,
+      lib,
+      pkgs,
+      ...
+    }: {
+      options.jackpkgs.images = {
+        commonPackages = mkOption {
+          type = types.listOf types.package;
+          default = with pkgs; [bashInteractive cacert coreutils iana-etc];
+          defaultText = lib.literalExpression "[ pkgs.bashInteractive pkgs.cacert pkgs.coreutils pkgs.iana-etc ]";
+          description = ''
+            Packages included in the shared common layer of every image.
+            These are combined into a single buildEnv and emitted as one layer,
+            so they are stored only once in the registry.
+          '';
+        };
+
+        images = mkOption {
+          type = types.attrsOf (types.submodule ({name, ...}: {
+            options = {
+              name = mkOption {
+                type = types.str;
+                default = lib.mkOptionDefault name;
+                description = "Image name. Defaults to the attribute key name.";
+              };
+
+              packages = mkOption {
+                type = types.listOf types.package;
+                default = [];
+                description = "Per-image packages added as individual layers (after the common layer).";
+              };
+
+              entrypoint = mkOption {
+                type = types.listOf types.str;
+                default = [];
+                description = "OCI entrypoint (e.g. [\"/bin/my-app\"]).";
+              };
+
+              cmd = mkOption {
+                type = types.nullOr (types.listOf types.str);
+                default = null;
+                description = "OCI cmd (default command arguments).";
+              };
+
+              env = mkOption {
+                type = types.listOf types.str;
+                default = [];
+                description = "OCI environment variables in KEY=VAL format. SSL_CERT_FILE is injected automatically.";
+              };
+
+              workingDir = mkOption {
+                type = types.str;
+                default = "/workspace";
+                description = "Working directory inside the container.";
+              };
+
+              tag = mkOption {
+                type = types.str;
+                default = "latest";
+                description = "Default tag for the image.";
+              };
+
+              extraLayers = mkOption {
+                type = types.listOf types.unspecified;
+                default = [];
+                description = ''
+                  Raw nix2container layers to append (escape hatch for custom
+                  layering strategies like busybox /bin/sh for Cloud Run).
+                '';
+              };
+
+              registry = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = "Per-image registry override. Falls back to jackpkgs.images.registry.";
+              };
+            };
+          }));
+          default = {};
+          description = "Container images to build. Each key becomes an image in flake.images.<key>.";
+        };
+      };
+    });
+  };
+
+  config = mkIf cfg.enable {
+    # Per-system config: just recipes and skopeo package
+    perSystem = {
+      pkgs,
+      lib,
+      config,
+      system,
+      ...
+    }: let
+      sysCfg = config.jackpkgs.images;
+      nix2container = jackpkgsInputs.nix2container.packages.${cfg.linuxSystem}.nix2container;
+      skopeoNix2container = jackpkgsInputs.nix2container.packages.${cfg.linuxSystem}.skopeo-nix2container;
+
+      imageNames = lib.attrNames sysCfg.images;
+
+      # Resolve registry for a given image config key
+      resolveRegistry = imageKey: let
+        imageCfg = sysCfg.images.${imageKey};
+      in
+        if imageCfg.registry != null
+        then imageCfg.registry
+        else if cfg.registry != null
+        then cfg.registry
+        else throw "jackpkgs.images: registry must be set either globally (jackpkgs.images.registry) or per-image (jackpkgs.images.images.<name>.registry)";
+
+      # Auth credential derivation based on authMode
+      credsExpr =
+        if cfg.authMode == "gcp"
+        then "\"oauth2accesstoken:$(gcloud auth print-access-token)\""
+        else "\"\${GITHUB_ACTOR}:\${GITHUB_TOKEN}\"";
+
+      imageBuildRecipe = mkRecipeWithParams "image-build" [''name''] "Build a container image locally (produces ./result JSON manifest)" [
+        "nix build .#images.{{name}}"
+      ] false;
+
+      imageDigestRecipe = mkRecipeWithParams "image-digest" [''name''] "Show the SHA256 digest of a locally-built image" [
+        "#!/usr/bin/env bash"
+        "set -euo pipefail"
+        "nix build .#images.{{name}}"
+        "${lib.getExe skopeoNix2container} inspect nix:./result | ${lib.getExe pkgs.jq} -r '.Digest'"
+      ] false;
+
+      imagePushRecipe = mkRecipeWithParams "image-push" [''name'' ''tag=\"latest\"''] "Push a single image to its configured registry" (
+        [
+          "#!/usr/bin/env bash"
+          "set -euo pipefail"
+          "nix build .#images.{{name}}"
+        ]
+        ++ lib.concatMap (imgName: let
+          reg = resolveRegistry imgName;
+        in [
+          "if [ \"{{name}}\" = \"${imgName}\" ]; then"
+          "  DEST=\"${reg}/${imgName}:{{tag}}\""
+          "fi"
+        ])
+        imageNames
+        ++ [
+          "CREDS=${credsExpr}"
+          "${lib.getExe skopeoNix2container} copy --dest-creds \"$CREDS\" nix:./result \"docker://$DEST\""
+        ]
+      ) false;
+
+      imagePushAllRecipe = mkRecipeWithParams "image-push-all" [''tag=\"latest\"''] "Push all images defined in jackpkgs.images.images" (
+        [
+          "#!/usr/bin/env bash"
+          "set -euo pipefail"
+        ]
+        ++ map (imgName: "just image-push ${imgName} {{tag}}") imageNames
+      ) false;
+    in {
+      # Expose skopeo-nix2container for direct use
+      packages.skopeo-nix2container = skopeoNix2container;
+
+      just-flake = {
+        features.images = {
+          enable = true;
+          justfile = lib.concatStringsSep "\n\n" (
+            [imageBuildRecipe imageDigestRecipe]
+            ++ lib.optional (imageNames != []) imagePushRecipe
+            ++ lib.optional (imageNames != []) imagePushAllRecipe
+          );
+        };
+      };
+    };
+
+    # Top-level flake.images output — images are Linux-only, NOT perSystem packages.
+    # Use getSystem to access the perSystem config for linuxSystem.
+    flake.images = let
+      linuxSysCfg = (getSystem cfg.linuxSystem).jackpkgs.images;
+      nix2container = jackpkgsInputs.nix2container.packages.${cfg.linuxSystem}.nix2container;
+      linuxPkgs = jackpkgsInputs.nixpkgs.legacyPackages.${cfg.linuxSystem};
+    in
+      builtins.mapAttrs (imageName: imageCfg: let
+        # Build common layer from commonPackages
+        commonLayer =
+          if linuxSysCfg.commonPackages != []
+          then
+            nix2container.buildLayer {
+              copyToRoot = linuxPkgs.buildEnv {
+                name = "common-env";
+                paths = linuxSysCfg.commonPackages;
+              };
+            }
+          else null;
+
+        baseLayers =
+          if commonLayer != null
+          then [commonLayer]
+          else [];
+
+        # Fold per-image packages into layers, deduplicating against common layer
+        imageLayers = foldImageLayers nix2container baseLayers imageCfg.packages;
+
+        # Inject SSL_CERT_FILE automatically
+        sslEnv = "SSL_CERT_FILE=${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        imageEnv = imageCfg.env ++ [sslEnv];
+      in
+        nix2container.buildImage {
+          name = imageCfg.name;
+          tag = imageCfg.tag;
+          layers = imageLayers ++ imageCfg.extraLayers;
+          config = {
+            Entrypoint = imageCfg.entrypoint;
+            Cmd = imageCfg.cmd;
+            Env = imageEnv;
+            WorkingDir = imageCfg.workingDir;
+          };
+        })
+      linuxSysCfg.images;
+  };
+}

--- a/modules/flake-parts/default.nix
+++ b/modules/flake-parts/default.nix
@@ -17,6 +17,7 @@
       pulumi = import ./pulumi.nix {jackpkgsInputs = inputs;};
       quarto = import ./quarto.nix {jackpkgsInputs = inputs;};
       python = import ./python.nix {jackpkgsInputs = inputs;};
+      container = import ./container.nix {jackpkgsInputs = inputs;};
     };
   };
 }


### PR DESCRIPTION
## What

Implements ADR-030: a `flake-parts/container.nix` module that standardizes nix2container image building across consumer repos.

Refs ergodicsystems/hq#135

## Why

yard and zeus both independently implement the same nix2container image pattern with manual `buildImage` boilerplate, no layer deduplication, and duplicated common packages. A shared module in jackpkgs centralizes this.

## Changes

**New files:**
- `modules/flake-parts/container.nix` (280 lines) -- the flake-parts module

**Modified files:**
- `flake.nix` -- added `nix2container` input (follows nixpkgs)
- `modules/flake-parts/all.nix` -- registered container module
- `modules/flake-parts/default.nix` -- exposed `flakeModules.container`
- `flake.lock` -- updated with nix2container pin
- `docs/internal/designs/030-container-image-flake-module.md` -- status: Proposed -> Accepted

## Module options

**Top-level:**
- `jackpkgs.images.enable` (bool, default false)
- `jackpkgs.images.linuxSystem` (string, default "x86_64-linux")
- `jackpkgs.images.registry` (string, required when enabled)
- `jackpkgs.images.authMode` (enum: "gcp" | "ghcr", default "gcp")

**Per-system:**
- `jackpkgs.images.commonPackages` (listOf pkg, defaults to bashInteractive + cacert + coreutils + iana-etc)
- `jackpkgs.images.images` (attrsOf image submodule)

**Per-image submodule:**
- `name`, `packages`, `entrypoint`, `cmd`, `env`, `workingDir`, `tag`, `extraLayers`, `registry`

## What it provides

- `flake.images.<name>` -- top-level flake output with built image derivations (NOT in perSystem packages, since images are Linux-only)
- `foldImageLayers` helper -- deduplicates layers across images so common packages appear once
- `skopeo-nix2container` exposed as a perSystem package (pinned to nix2container's version)
- Just recipes: `image-build`, `image-digest`, `image-push`, `image-push-all`

## Consumer usage (yard example)

```nix
# In the consumer's flake.nix:
imports = [ inputs.jackpkgs.flakeModules.container ];

jackpkgs.images = {
  enable = true;
  registry = "us-east1-docker.pkg.dev/addenda-dev/addenda";
  commonPackages = [ pkgs.bashInteractive pkgs.cacert pkgs.coreutils pkgs.iana-etc ];
  images = {
    lens-api = {
      packages = [ self'.packages.lens-api ];
      entrypoint = [ "/bin/dumb-init" "--" "/entrypoint.sh" ];
      env = [ "PYTHONUNBUFFERED=1" ];
    };
  };
};
# Then: nix build .#images.lens-api
```

## Verification

`nix flake check --no-build` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new flake output (`flake.images`) and Linux-gated just recipes for building/pushing images, which could affect consumer build/push workflows and evaluation on non-Linux systems if misconfigured. Risk is moderated by being opt-in via `jackpkgs.images.enable` and pinned `nix2container`.
> 
> **Overview**
> Implements **ADR-030** by adding a new `modules/flake-parts/container.nix` module that, when `jackpkgs.images.enable` is set, generates Linux-only container images under the top-level `flake.images.<name>` output using `nix2container`, including a shared common layer and per-image layer deduplication.
> 
> The module also contributes standardized `just` recipes (`image-build`, `image-digest`, `image-push`, `image-push-all`) and exposes `skopeo-nix2container` for pushing to registries with configurable auth (`gcp` or `ghcr`) and per-image registry overrides.
> 
> Wires the module into the flake module set (`all.nix`/`default.nix`), adds and pins the `nix2container` flake input (`flake.nix`/`flake.lock`), and marks the design ADR as **Accepted**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ec2ccdde1fdf733dcc056eb09f62926c70f106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->