### PR TITLE
fix(devshell): suppress welcome banner when stdout is not a TTY

### DIFF
--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -82,35 +82,59 @@ in {
       sysCfg = config.jackpkgs.shell;
       mkShellEnvHook = import ../../lib/shell-env-hook.nix {inherit lib pkgs;};
 
+      # Reconstruct the just-flake common justfile so we can manage the symlink
+      # ourselves instead of relying on just-flake's hardcoded shellHook (which
+      # unconditionally echoes emoji text and runs `just --list` to stdout,
+      # breaking non-interactive `nix develop -c` invocations).
+      justFlakeCfg = config.just-flake;
+      commonJustfile = pkgs.writeTextFile {
+        name = "justfile";
+        text = lib.concatStringsSep "\n"
+          (lib.mapAttrsToList (_name: feature: feature.outputs.justfile) justFlakeCfg.features);
+      };
+
       # Build shellHook segments as a list and join with newlines for safe concatenation.
       # Durable environment variables are carried by setup hooks from pulumiDevShell,
       # which is already included via sysCfg.inputsFrom (set by the pulumi module).
       shellHookParts =
-        lib.optional (gcpProfile != null) (
+        [
+          # Symlink the generated justfile (essential for just recipe discovery).
+          # Replaces just-flake's own shellHook which also does this but adds
+          # unconditional stdout noise (emoji echo + `just --list`).
+          ''ln -sf ${builtins.toString commonJustfile} ./${justFlakeCfg.commonFileName}''
+        ]
+        ++ lib.optional (gcpProfile != null) (
           if builtins.match "[a-zA-Z0-9._-]+" gcpProfile == null
           then throw "jackpkgs.gcp.profile contains invalid characters. Only [a-zA-Z0-9._-] are allowed."
           else ''
             export CLOUDSDK_CONFIG="$HOME/.config/gcloud-profiles/${gcpProfile}"
-            export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud-profiles/${gcpProfile}/application_default_credentials.json"
+            export GOOGLE_APPLICATION_CREDENTIALS="$HOME/...json"
             mkdir -p "$CLOUDSDK_CONFIG"
           ''
         )
         ++ lib.optionals cfg.welcome.enable (
           lib.optional (cfg.welcome.message != null) ''[ -t 1 ] && echo ${lib.escapeShellArg cfg.welcome.message}''
           ++ lib.optional cfg.welcome.showJustHint ''[ -t 1 ] && echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
+          ++ [''[ -t 1 ] && just --list'']
         );
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell {
         inputsFrom =
           [
-            config.just-flake.outputs.devShell
+            # NOTE: config.just-flake.outputs.devShell is intentionally excluded.
+            # It hardcodes `echo + just --list` in its shellHook, which pollutes
+            # stdout for non-interactive `nix develop -c` invocations. We replicate
+            # its essential behavior (symlink + just binary) with TTY-gated output.
             config.flake-root.devShell
             config.pre-commit.devShell
             config.treefmt.build.devShell
           ]
           ++ sysCfg.inputsFrom;
         packages =
-          sysCfg.packages
+          # just was previously provided by just-flake's devShell via inputsFrom;
+          # now we include it directly since we dropped that inputsFrom entry.
+          [pkgs.just]
+          ++ sysCfg.packages
           ++ lib.optional (!cfg.direnv.showEnvDiff) (
             mkShellEnvHook {
               name = "jackpkgs-direnv-log-format-hook";

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -115,7 +115,6 @@ in {
         ++ lib.optionals cfg.welcome.enable (
           lib.optional (cfg.welcome.message != null) ''[ -t 1 ] && echo ${lib.escapeShellArg cfg.welcome.message}''
           ++ lib.optional cfg.welcome.showJustHint ''[ -t 1 ] && echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
-          ++ [''[ -t 1 ] && just --list'']
         );
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell {

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -96,8 +96,8 @@ in {
           ''
         )
         ++ lib.optionals cfg.welcome.enable (
-          lib.optional (cfg.welcome.message != null) ''echo ${lib.escapeShellArg cfg.welcome.message}''
-          ++ lib.optional cfg.welcome.showJustHint ''echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
+          lib.optional (cfg.welcome.message != null) ''[ -t 1 ] && echo ${lib.escapeShellArg cfg.welcome.message}''
+          ++ lib.optional cfg.welcome.showJustHint ''[ -t 1 ] && echo ${lib.escapeShellArg cfg.welcome.justHintMessage}''
         );
     in {
       jackpkgs.outputs.devShell = pkgs.mkShell {


### PR DESCRIPTION
## Problem

Downstream consumers (e.g. `addendalabs/yard`) run `nix develop ... -c python3 -c "..."` inside Pulumi `Command` scripts. The devshell `shellHook` had two sources of stdout pollution:

1. **jackpkgs welcome banner** — `echo` of welcome message and just hint (unconditional)
2. **just-flake upstream shellHook** — emoji echo + `just --list` (unconditional, hardcoded in juspay/just-flake `flake-module.nix:54-60`)

Both break command substitution (`VAR=$(nix develop ... -c ...)`), requiring `| tail -n 1` workarounds and `set -o pipefail` hacks.

## Fix

**Commit 1**: Gate the welcome banner echo on `[ -t 1 ]` (POSIX TTY check on stdout).

**Commit 2**: Remove `config.just-flake.outputs.devShell` from `inputsFrom` entirely (its devShell option is `readOnly` with a hardcoded shellHook, so overriding is not possible). Replicate its essential behavior in jackpkgs:
- Justfile symlink (essential for recipe discovery) — always runs
- `just` binary — added directly to packages (was previously inherited via inputsFrom)
- `just --list` — gated on `[ -t 1 ]`, only fires in interactive sessions

Interactive `nix develop` sessions are unchanged: stdout is a TTY, so banner and recipe listing print as before. Non-interactive `nix develop -c` invocations get completely clean stdout.

## Testing

- `nix flake check --no-build` passes all derivations on aarch64-darwin

Closes #212

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes devshell composition (drops `config.just-flake.outputs.devShell`) and `shellHook` behavior, which could affect developer workflow and `just` recipe discovery if assumptions differ across projects.
> 
> **Overview**
> Removes unconditional stdout output during `nix develop -c` by **TTY-gating** the devshell welcome banner (`[ -t 1 ] && echo ...`).
> 
> Stops inheriting `just-flake`’s devShell (which hardcodes noisy `shellHook` output), and instead recreates only the required behavior in this module: generate/symlink the shared `justfile` and add `pkgs.just` directly to the devshell packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aafb7b6bed9d903811d7f9c7499d4e0f9e15d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->