### PR TITLE
feat: add kubeconfig flake-parts module (ADR-035)

### DIFF
--- a/docs/internal/designs/035-shared-kubeconfig-recipe.md
+++ b/docs/internal/designs/035-shared-kubeconfig-recipe.md
@@ -1,0 +1,131 @@
+# ADR-035: Shared `just kubeconfig` Recipe
+
+## Status
+
+Proposed
+
+## Context
+
+- Three repos (garden, yard, zeus) each need `just kubeconfig` to configure kubectl for local use.
+- Each has a hand-written recipe with different cluster auth mechanisms (mTLS certs via Pulumi TLS provider, `gcloud get-credentials`, decomposed config secrets).
+- The zeus recipe was broken after a directory rename and has been deleted.
+- Garden and yard each maintain their own recipe, diverging in mechanism and output path.
+- All three repos use jackpkgs for Pulumi devshell and justfile generation (via `jackpkgs.pulumi` and `just-flake.features`).
+- Garden already sets `$KUBECONFIG` to a repo-local path (`$REPO_ROOT/kubeconfig.yaml`) in its devshell. Yard writes to `~/.kube/config`.
+
+## Decision
+
+Add a `jackpkgs.kubeconfig` flake-parts module that:
+
+1. Declares a `kubeconfig` stack output contract: every k8s Pulumi stack MUST export a `kubeconfig` output containing a complete kubeconfig YAML.
+2. Generates a single `just kubeconfig` recipe that reads that output and writes to `$KUBECONFIG`.
+3. Sets `$KUBECONFIG` to `$REPO_ROOT/kubeconfig.yaml` in the devshell when enabled.
+
+The generated recipe is always:
+
+```
+pulumi -C <path> stack output kubeconfig --stack <stack> --show-secrets > "$KUBECONFIG"
+```
+
+What varies between repos is the Pulumi program that produces the kubeconfig (mTLS, GKE exec auth, config secret re-export). The consumer recipe is identical.
+
+### Option: `jackpkgs.kubeconfig`
+
+```nix
+jackpkgs.kubeconfig = {
+  enable = true;
+  pulumiStackOutput = {
+    path = "deploy/platform/k8s";
+    stack = "prod";
+  };
+};
+```
+
+- `enable` (bool, default false): activates the kubeconfig recipe and `$KUBECONFIG` env var.
+- `pulumiStackOutput.path` (str, required): Pulumi project directory relative to repo root.
+- `pulumiStackOutput.stack` (str, default `"prod"`): stack name to query.
+
+### Generated recipe
+
+```just
+# Write kubeconfig from Pulumi stack output to $KUBECONFIG
+kubeconfig:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "${KUBECONFIG:-}" ]; then
+      echo "KUBECONFIG not set — run from the nix devshell" >&2
+      exit 1
+    fi
+    pulumi -C deploy/platform/k8s stack output kubeconfig --stack prod --show-secrets > "$KUBECONFIG"
+    echo "kubeconfig written to $KUBECONFIG"
+```
+
+### `$KUBECONFIG` in devshells
+
+When `jackpkgs.kubeconfig.enable` is true, the module exports:
+
+```nix
+KUBECONFIG = "$REPO_ROOT/kubeconfig.yaml"
+```
+
+using the same `flake-root` pattern as garden's existing devshell. This keeps per-repo clusters isolated from each other and from `~/.kube/config`.
+
+`kubeconfig.yaml` should be in `.gitignore` per-repo.
+
+## Consequences
+
+### Benefits
+
+- One recipe, one mechanism across all repos. The auth complexity stays inside the Pulumi program.
+- New repos with k8s clusters get `just kubeconfig` by adding three lines to their `flake.nix`.
+- Repo-local `$KUBECONFIG` prevents clobbering `~/.kube/config` when switching between repos.
+- The contract is simple: if your Pulumi stack exports `kubeconfig`, you get the recipe.
+
+### Trade-offs
+
+- Yard must create a new Pulumi k8s platform stack that composes a GKE kubeconfig with the exec auth plugin. Currently yard calls `gcloud get-credentials` directly.
+- Garden must remove its hand-written `$KUBECONFIG` export from `nix/devshell.nix` and hand-written `kubeconfig` recipe from its justfile.
+- `$KUBECONFIG` shadowing: setting it in the devshell hides `~/.kube/config`. Users who rely on a global kubeconfig must run `just kubeconfig` in each repo. This is already garden's convention.
+
+### Risks & Mitigations
+
+- **Yard GKE kubeconfig correctness.** The composed kubeconfig with GKE exec auth plugin must match what `gcloud get-credentials` produces. Mitigation: test with `kubectl get nodes` before removing the old recipe.
+- **Stack output must be a Pulumi secret.** The `kubeconfig` output contains auth material. The Pulumi program MUST wrap it with `pulumi.secret()` so `--show-secrets` is required to read it. Mitigation: document this as a hard requirement; add a check in the generated recipe.
+- **Module placement.** This is a small module that integrates with both the devshell and just.nix features. It could live as a standalone module or as an extension to just.nix's infra feature. Mitigation: standalone module keeps concerns separated; the justfile content is wired into the infra feature via `config.jackpkgs.outputs.kubeconfigJustfile`.
+
+## Alternatives Considered
+
+### Alternative A — Extend just.nix infra feature inline
+
+Add `jackpkgs.kubeconfig` options directly in just.nix alongside the existing pulumi options.
+
+- Pros: fewer files, no new module registration.
+- Cons: just.nix is already 616 lines. Adding kubeconfig options, recipe generation, and devshell env var logic would further bloat it. The kubeconfig concern is distinct from auth/preview/deploy.
+
+### Alternative B — Per-repo hand-written recipes (status quo)
+
+Keep each repo's hand-written recipe.
+
+- Pros: no shared module to maintain.
+- Cons: zeus recipe is already broken. Yard uses a different mechanism. Garden's recipe works but is not discoverable as a shared pattern. Every new repo duplicates the recipe.
+
+## Implementation Plan
+
+1. Create `modules/flake-parts/kubeconfig.nix` with options and config blocks.
+2. Register in `all.nix` and `default.nix`.
+3. Wire `kubeconfigJustfile` output into just.nix's infra feature (alongside `pulumiJustfile`).
+4. Wire `$KUBECONFIG` env var via the devshell module's `inputsFrom` pattern.
+5. Adopt in garden, zeus, yard (separate PRs per repo).
+
+## Related
+
+- Garden `justfile` lines 7-10: existing working kubeconfig recipe
+- Garden `nix/devshell.nix` line 65: existing `$KUBECONFIG` export
+- Yard `justfile` line 261: `gcloud get-credentials` recipe
+- Zeus `deploy/platform/k8s/index.ts`: stores kubeconfig as config secret, re-exports as stack output
+- ADR-034: Devshell Composition Contract (shell env hook pattern)
+
+______________________________________________________________________
+
+Author: Jack Maloney
+Date: 2026-05-08

--- a/modules/flake-parts/all.nix
+++ b/modules/flake-parts/all.nix
@@ -14,5 +14,6 @@
     (import ./quarto.nix {inherit jackpkgsInputs;})
     (import ./checks.nix {inherit jackpkgsInputs;})
     (import ./container.nix {inherit jackpkgsInputs;})
+    (import ./kubeconfig.nix {inherit jackpkgsInputs;})
   ];
 }

--- a/modules/flake-parts/default.nix
+++ b/modules/flake-parts/default.nix
@@ -18,6 +18,7 @@
       quarto = import ./quarto.nix {jackpkgsInputs = inputs;};
       python = import ./python.nix {jackpkgsInputs = inputs;};
       container = import ./container.nix {jackpkgsInputs = inputs;};
+      kubeconfig = import ./kubeconfig.nix {jackpkgsInputs = inputs;};
     };
   };
 }

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -306,6 +306,7 @@ in {
                 [authRecipe]
                 ++ lib.optional (cfg.gcp.profile != null) authStatusRecipe
                 ++ lib.optional (cfg.pulumi.enable && cfg.pulumi.stacks != []) config.jackpkgs.outputs.pulumiJustfile
+                ++ lib.optional cfg.kubeconfig.enable config.jackpkgs.outputs.kubeconfigJustfile
                 ++ [
                   # new-stack recipe
                   "# Create a new Pulumi stack (usage: just new-stack <project-path> <stack-name>)"

--- a/modules/flake-parts/kubeconfig.nix
+++ b/modules/flake-parts/kubeconfig.nix
@@ -6,7 +6,6 @@
 }: let
   inherit (lib) mkIf;
   cfg = config.jackpkgs.kubeconfig;
-  pulumiCfg = config.jackpkgs.pulumi;
 
   justfileHelpers = import ../../lib/justfile-helpers.nix {inherit lib;};
   inherit (justfileHelpers) mkRecipe;

--- a/modules/flake-parts/kubeconfig.nix
+++ b/modules/flake-parts/kubeconfig.nix
@@ -1,5 +1,4 @@
 {jackpkgsInputs}: {
-  inputs,
   config,
   lib,
   ...
@@ -15,7 +14,7 @@ in {
     inherit (jackpkgsInputs.flake-parts.lib) mkDeferredModuleOption;
   in {
     jackpkgs.kubeconfig = {
-      enable = mkEnableOption "jackpkgs-kubeconfig" // {default = false;};
+      enable = mkEnableOption "jackpkgs-kubeconfig";
 
       pulumiStackOutput = mkOption {
         type = types.submodule {
@@ -72,7 +71,7 @@ in {
 
         kubeconfigRecipe =
           mkRecipe "kubeconfig"
-          "Write kubeconfig from Pulumi stack output to \\$KUBECONFIG"
+          "Write kubeconfig from Pulumi stack output to $KUBECONFIG"
           [
             "#!/usr/bin/env bash"
             "set -euo pipefail"
@@ -80,8 +79,8 @@ in {
             "  echo \"KUBECONFIG not set — run from the nix devshell\" >&2"
             "  exit 1"
             "fi"
-            "${pulumiExe} -C ${lib.escapeShellArg cfg.pulumiStackOutput.path} stack output kubeconfig --stack ${lib.escapeShellArg cfg.pulumiStackOutput.stack} --show-secrets > \"\\$KUBECONFIG\""
-            "echo \"kubeconfig written to \\$KUBECONFIG\""
+            "${pulumiExe} -C ${lib.escapeShellArg cfg.pulumiStackOutput.path} stack output kubeconfig --stack ${lib.escapeShellArg cfg.pulumiStackOutput.stack} --show-secrets > \"$KUBECONFIG\""
+            "echo \"kubeconfig written to $KUBECONFIG\""
           ]
           false;
       in {

--- a/modules/flake-parts/kubeconfig.nix
+++ b/modules/flake-parts/kubeconfig.nix
@@ -1,0 +1,102 @@
+{jackpkgsInputs}: {
+  inputs,
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkIf;
+  cfg = config.jackpkgs.kubeconfig;
+  pulumiCfg = config.jackpkgs.pulumi;
+
+  justfileHelpers = import ../../lib/justfile-helpers.nix {inherit lib;};
+  inherit (justfileHelpers) mkRecipe;
+in {
+  options = let
+    inherit (lib) types mkOption mkEnableOption;
+    inherit (jackpkgsInputs.flake-parts.lib) mkDeferredModuleOption;
+  in {
+    jackpkgs.kubeconfig = {
+      enable = mkEnableOption "jackpkgs-kubeconfig" // {default = false;};
+
+      pulumiStackOutput = mkOption {
+        type = types.submodule {
+          options = {
+            path = mkOption {
+              type = types.str;
+              description = "Path to the Pulumi project directory (relative to repo root) that exports a 'kubeconfig' stack output.";
+            };
+            stack = mkOption {
+              type = types.str;
+              default = "prod";
+              description = "Pulumi stack name to query for the kubeconfig output.";
+            };
+          };
+        };
+        description = "Pulumi stack that exports a 'kubeconfig' output containing a complete kubeconfig YAML.";
+      };
+    };
+
+    perSystem = mkDeferredModuleOption ({
+      config,
+      lib,
+      pkgs,
+      ...
+    }: {
+      options.jackpkgs.outputs.kubeconfigJustfile = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = "Generated justfile fragment for the kubeconfig recipe.";
+      };
+
+      options.jackpkgs.outputs.kubeconfigDevShell = mkOption {
+        type = types.package;
+        readOnly = true;
+        description = "DevShell fragment that exports KUBECONFIG to a repo-local path.";
+      };
+    });
+  };
+
+  config =
+    mkIf cfg.enable
+    {
+      # Kubeconfig requires pulumi to be enabled (for the pulumi binary)
+      jackpkgs.pulumi.enable = lib.mkDefault true;
+
+      perSystem = {
+        pkgs,
+        lib,
+        config,
+        ...
+      }: let
+        pulumiExe = lib.getExe' pkgs.pulumi-bin "pulumi";
+        flakeRootExe = lib.getExe config.flake-root.package;
+
+        kubeconfigRecipe =
+          mkRecipe "kubeconfig"
+          "Write kubeconfig from Pulumi stack output to \\$KUBECONFIG"
+          [
+            "#!/usr/bin/env bash"
+            "set -euo pipefail"
+            "if [ -z \"\\${KUBECONFIG:-}\" ]; then"
+            "  echo \"KUBECONFIG not set — run from the nix devshell\" >&2"
+            "  exit 1"
+            "fi"
+            "${pulumiExe} -C ${lib.escapeShellArg cfg.pulumiStackOutput.path} stack output kubeconfig --stack ${lib.escapeShellArg cfg.pulumiStackOutput.stack} --show-secrets > \"\\$KUBECONFIG\""
+            "echo \"kubeconfig written to \\$KUBECONFIG\""
+          ]
+          false;
+      in {
+        jackpkgs.outputs.kubeconfigJustfile = kubeconfigRecipe;
+
+        jackpkgs.outputs.kubeconfigDevShell = pkgs.mkShell {
+          shellHook = ''
+            export KUBECONFIG="$(${flakeRootExe})/kubeconfig.yaml"
+          '';
+        };
+
+        jackpkgs.shell.inputsFrom = [
+          config.jackpkgs.outputs.kubeconfigDevShell
+        ];
+      };
+    };
+}


### PR DESCRIPTION
## Summary

New `jackpkgs.kubeconfig` flake-parts module that generates a `just kubeconfig` recipe from declarative Nix config.

**Problem:** Three repos (garden, yard, zeus) each need `just kubeconfig` to configure kubectl. Each has a hand-written recipe with different cluster auth mechanisms. The zeus recipe was broken and deleted.

**Solution:** A single strategy — every k8s Pulumi stack exports a `kubeconfig` stack output, and the generated recipe always does `pulumi stack output kubeconfig --show-secrets > $KUBECONFIG`. What varies between repos is the Pulumi program that produces the kubeconfig (mTLS, GKE exec auth, config secret re-export), not the consumer recipe.

## Artifacts

- `docs/internal/designs/035-shared-kubeconfig-recipe.md` — ADR documenting the decision
- `modules/flake-parts/kubeconfig.nix` — the new module (102 lines)
- Wiring in `all.nix`, `default.nix`, and `just.nix`

## Usage

```nix
jackpkgs.kubeconfig = {
  enable = true;
  pulumiStackOutput = {
    path = "deploy/platform/k8s";
    stack = "prod";
  };
};
```

This gives you:
- `just kubeconfig` recipe in the infra feature
- `$KUBECONFIG` set to `$REPO_ROOT/kubeconfig.yaml` in the devshell

## What the module does

1. Declares `jackpkgs.kubeconfig` options (`enable`, `pulumiStackOutput.path`, `pulumiStackOutput.stack`)
2. Generates a bash recipe that validates `$KUBECONFIG` is set, then reads the Pulumi stack output
3. Creates a devShell fragment that exports `KUBECONFIG` to a repo-local path via `flake-root`
4. Wires the justfile output into the existing `infra` just-flake feature alongside pulumi preview/deploy
5. Auto-enables `jackpkgs.pulumi` (kubeconfig needs the pulumi binary)

## Migration plan (follow-up PRs per repo)

- **garden**: Add kubeconfig config to `flake.nix`. Remove hand-written recipe from justfile. Remove `$KUBECONFIG` export from `nix/devshell.nix`.
- **zeus**: Add kubeconfig config to `flake.nix`. Recipe deletion already done.
- **yard**: Add kubeconfig config to `flake.nix`. Create `deploy/platform/k8s` Pulumi stack that exports GKE kubeconfig with exec auth plugin. Remove hand-written recipe.

## Test plan

- [x] `nix flake check --no-build` passes (all existing checks green)
- [ ] Manual: `nix develop` in a repo with `jackpkgs.kubeconfig.enable = true` and verify `just --list` shows `kubeconfig`
- [ ] Manual: `just kubeconfig` in each repo after migration and verify `kubectl get nodes` works

## Risks

- Yard needs a new Pulumi k8s platform stack (most complex migration)
- `$KUBECONFIG` shadowing: repo-local path hides `~/.kube/config` (already garden convention)
- Stack output must be a Pulumi secret (`pulumi.secret()`) since it contains auth material

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional module that sets `KUBECONFIG` in devshells and writes kubeconfig from Pulumi stack outputs; misconfiguration could break local kubectl access or unintentionally override users’ global kubeconfig while in the shell.
> 
> **Overview**
> Introduces **ADR-035** documenting a standardized, repo-agnostic approach for generating kubeconfigs via Pulumi stack output.
> 
> Adds a new `jackpkgs.kubeconfig` flake-parts module that (when enabled) **generates a `just kubeconfig` recipe** to fetch `stack output kubeconfig --show-secrets` and **injects a devshell hook** that sets `KUBECONFIG` to a repo-local `kubeconfig.yaml`.
> 
> Wires the module into the flake module registry (`all.nix`/`default.nix`) and into the existing `just` infra feature so the kubeconfig recipe is included alongside Pulumi recipes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3945cf7dcec7d8033d0a6088955d4b03995a3dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->