### PR TITLE
feat(python): add ignoreCollisions option for venv file collisions

### DIFF
--- a/modules/flake-parts/python.nix
+++ b/modules/flake-parts/python.nix
@@ -122,6 +122,18 @@ in {
               '';
             };
 
+            ignoreCollisions = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = ''
+                fnmatch glob patterns for files to ignore during venv creation when
+                multiple packages provide the same path with different content.
+                Passed to pyproject.nix venvIgnoreCollisions.
+
+                Example: [ "*/site-packages/dbt/*" ]
+              '';
+            };
+
             passthru = mkOption {
               type = types.attrs;
               default = {};
@@ -358,12 +370,19 @@ in {
         mkEnvForSpec = {
           name,
           spec,
+          ignoreCollisions ? [],
         }:
-          addMainProgram (pythonSet.mkVirtualEnv name spec);
+          let
+            env = addMainProgram (pythonSet.mkVirtualEnv name spec);
+          in
+            if ignoreCollisions != []
+            then env.overrideAttrs (_: { venvIgnoreCollisions = ignoreCollisions; })
+            else env;
 
         mkEnv = {
           name,
           spec ? null,
+          ignoreCollisions ? [],
         }: let
           finalSpec =
             if spec == null
@@ -373,6 +392,7 @@ in {
           mkEnvForSpec {
             inherit name;
             spec = finalSpec;
+            inherit ignoreCollisions;
           };
 
         mkEditableEnv = {
@@ -380,6 +400,7 @@ in {
           spec ? null,
           members ? null,
           root ? null,
+          ignoreCollisions ? [],
         }: let
           finalSpec =
             if spec == null
@@ -395,7 +416,12 @@ in {
           overlayArgs = {root = finalRoot;} // lib.optionalAttrs (members != null) {inherit members;};
           editableSet = pythonSet.overrideScope (workspace.mkEditablePyprojectOverlay overlayArgs);
         in
-          addMainProgram (editableSet.mkVirtualEnv name finalSpec);
+          let
+            env = addMainProgram (editableSet.mkVirtualEnv name finalSpec);
+          in
+            if ignoreCollisions != []
+            then env.overrideAttrs (_: { venvIgnoreCollisions = ignoreCollisions; })
+            else env;
 
         pythonWorkspace = {
           inherit workspace pythonSet defaultSpec computeSpec;
@@ -431,11 +457,13 @@ in {
                   spec = finalSpec;
                   members = envCfg.members;
                   root = envCfg.editableRoot;
+                  inherit (envCfg) ignoreCollisions;
                 }
               else
                 pythonWorkspace.mkEnv {
                   name = envCfg.name;
                   spec = finalSpec;
+                  inherit (envCfg) ignoreCollisions;
                 }
           )
           cfg.environments;


### PR DESCRIPTION
## Problem

When multiple Python packages provide the same file with different content (e.g. `dbt-bigquery` and `dbt-core` both ship `dbt/__init__.py`), pyproject.nix `make_venv.py` raises `FileCollisionError` during venv creation, blocking the entire devshell.

pyproject.nix already supports `venvIgnoreCollisions` (fnmatch globs) via `overrideAttrs`, but jackpkgs does not expose this through its Python environment module.

## Fix

Adds an `ignoreCollisions` option (type `listOf str`, default `[]`) to the `jackpkgs.python.environments` submodule. When non-empty, it applies `overrideAttrs` with `venvIgnoreCollisions` to the resulting derivation.

Threaded through `mkEnvForSpec`, `mkEnv`, and `mkEditableEnv` so it works for both regular and editable environments.

## Usage

```nix
jackpkgs.python.environments.default = {
  name = "my-env";
  ignoreCollisions = [ "*/site-packages/dbt/*" ];
};
```

## Test plan

- [x] yard repo devshell builds successfully with `ignoreCollisions = ["*/site-packages/dbt/*"]` on both default and dev envs
- [ ] Existing jackpkgs consumers unaffected (default is `[]`, no overrideAttrs applied)

## Downstream

- yard PR: https://github.com/addendalabs/yard/pull/1184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in Nix option that only affects venv derivations when explicitly set, leaving existing environments unchanged by default.
> 
> **Overview**
> Adds a new `jackpkgs.python.environments.<name>.ignoreCollisions` option (list of fnmatch globs) to let consumers ignore specific file collisions during venv creation.
> 
> Threads this option through `mkEnvForSpec`, `mkEnv`, and `mkEditableEnv`, and when non-empty applies `overrideAttrs` to set `venvIgnoreCollisions` on the resulting virtualenv derivation for both editable and non-editable envs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b00eaa355142d67272d33217b7874f64ec02dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->