### PR TITLE
fix(container.nix): match nss-cacert pname instead of cacert

### DIFF
--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -289,7 +289,9 @@ in {
         # Inject SSL_CERT_FILE automatically using the consumer's cacert
         # (from commonPackages / per-image packages), not jackpkgs' pinned nixpkgs.
         cacertPkg =
-          lib.findFirst (p: p.pname or "" == "cacert") null
+          lib.findFirst
+          (p: lib.isAttrs p && lib.elem (p.pname or "") ["nss-cacert" "cacert"])
+          null
           (imageCfg.packages ++ linuxSysCfg.commonPackages);
         sslEnv =
           lib.optional (cacertPkg != null)


### PR DESCRIPTION
## Problem

The  predicate in `container.nix` checks `p.pname or "" == "cacert"`, but `pkgs.cacert` in nixpkgs has `pname = "nss-cacert"`, not `"cacert"\.

This means `cacertPkg` is always `null` and `SSL_CERT_FILE` is never injected into images.

## Impact

Every image built with `container.nix` will silently lack SSL certificate configuration, causing HTTPS failures at runtime. `curl`, `git`, Python `requests`, Go (CGO), and any TLS client library that relies on the system CA bundle will fail.

## Fix

Change the predicate to match `pname == "nss-cacert"`:

```nix
cacertPkg = lib.findFirst (p: p.pname or "" == "nss-cacert") null
  (imageCfg.packages ++ linuxSysCfg.commonPackages);
```

Fixes #268

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small predicate change in image env generation, but it affects all built images’ TLS behavior by enabling CA bundle configuration.
> 
> **Overview**
> Fixes container image environment generation in `modules/flake-parts/container.nix` so `SSL_CERT_FILE` is injected when the CA bundle package has `pname` `nss-cacert` (and still supports `cacert`).
> 
> This prevents images from being built without system CA certificate configuration, avoiding runtime HTTPS/TLS failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdbf44957352102bf2816d8a5675d4aea8480063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->