### PR TITLE
feat: default jackpkgs Python to 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
     - `pyprojectPath` (str, default `./pyproject.toml`)
     - `uvLockPath` (str, default `./uv.lock`)
     - `workspaceRoot` (str, default `.`)
-    - `pythonPackage` (package, default `config.jackpkgs.pkgs.python312`)
+    - `pythonPackage` (package, default `config.jackpkgs.pkgs.python314`)
     - `sourcePreference` ("wheel" | "sdist", default "wheel")
     - `setuptools.packages` (list of str)
     - `environments` (attrset of env defs: `{ name, spec, editable, editableRoot, members, passthru, includeGroups }`)

--- a/docs/internal/designs/003-python-flake-parts-module.md
+++ b/docs/internal/designs/003-python-flake-parts-module.md
@@ -44,7 +44,7 @@ Path: `jackpkgs/modules/flake-parts/python.nix`
 
 - Per-system additions:
 
-  - `jackpkgs.python.pythonPackage` (package; default `pkgs.python312`)
+  - `jackpkgs.python.pythonPackage` (package; default `pkgs.python314`)
   - Read-only output `jackpkgs.outputs.pythonEditableHook` (automatically included in devshell)
 
 - Preconditions and assertions:

--- a/docs/internal/designs/037-python-314-default-interpreter.md
+++ b/docs/internal/designs/037-python-314-default-interpreter.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/internal/designs/037-python-314-default-interpreter.md
+++ b/docs/internal/designs/037-python-314-default-interpreter.md
@@ -1,0 +1,83 @@
+# ADR-037: Bump the Default Python Interpreter to 3.14
+
+## Status
+
+Proposed
+
+## Context
+
+- `jackpkgs.python.pythonPackage` currently defaults to `pkgs.python312`.
+- `pkgs/nautilus-trader/default.nix` also defaults to `python312` when callers do not provide an explicit interpreter.
+- The repo already supports Python 3.14 in downstream consumers, and the 3.14 line is stable enough to be the default for new consumers.
+- Keeping the default one minor behind creates avoidable churn for consumers that expect the flake to follow the supported baseline.
+- Existing consumers can already override the interpreter explicitly when they need a different version.
+
+## Decision
+
+- `jackpkgs.python.pythonPackage` MUST default to `pkgs.python314`.
+- Package definitions that follow the default interpreter, including `nautilus-trader`, SHOULD also default to Python 3.14 unless they have a stronger reason to pin something else.
+- The override path remains unchanged: consumers MAY still set `jackpkgs.python.pythonPackage` or pass a different interpreter into package call sites.
+- This change is limited to jackpkgs defaults and documentation. It does not force consumers to adopt Python 3.14.
+
+## Consequences
+
+### Benefits
+
+- New consumers get the current supported baseline by default.
+- The default matches the interpreter line already validated in downstream projects.
+- Fewer projects need to override the interpreter just to avoid falling behind the supported baseline.
+
+### Trade-offs
+
+- Consumers that still need Python 3.12 or 3.13 must opt out explicitly.
+- A default bump can surface compatibility gaps earlier in package builds and tests.
+
+### Risks & Mitigations
+
+- Risk: one or more packages may still assume 3.12-era behavior.
+  - Mitigation: keep per-package overrides, and require the package to opt into a different interpreter only where needed.
+- Risk: downstream consumers may rely on the old default implicitly.
+  - Mitigation: the change is limited to defaults; explicit overrides continue to work and the README documents the new default.
+- Risk: stale docs or tests could drift from the implementation.
+  - Mitigation: update module docs, README, and the module tests in the same change.
+
+## Alternatives Considered
+
+### Alternative A — Keep the default on Python 3.12
+
+- Pros: zero immediate behavior change for existing consumers.
+- Cons: leaves the default one minor behind the validated baseline and keeps extra override burden on new consumers.
+- Why not chosen: the repo has already validated 3.14 and should expose that as the default.
+
+### Alternative B — Keep the default dynamic and inherit the consumer’s `pkgs.python3Packages.python`
+
+- Pros: lets each consumer decide via its nixpkgs revision.
+- Cons: makes the jackpkgs default less explicit and harder to reason about across repos.
+- Why not chosen: jackpkgs is meant to provide opinionated defaults, not defer the decision entirely.
+
+### Alternative C — Bump only package call sites, not the module default
+
+- Pros: minimal surface area.
+- Cons: consumers using the Python module would still land on the old default.
+- Why not chosen: the module default is the primary user-facing behavior.
+
+## Implementation Plan
+
+- Update `modules/flake-parts/python.nix` to default `jackpkgs.python.pythonPackage` to `pkgs.python314`.
+- Update package defaults that still hardcode `python312` to `python314`.
+- Update the module README, design notes, and tests to match the new baseline.
+- Validate with the standard jackpkgs checks before opening the PR.
+
+## Related
+
+- `docs/internal/designs/003-python-flake-parts-module.md`
+- `README.md`
+- `modules/flake-parts/python.nix`
+- `pkgs/nautilus-trader/default.nix`
+- `tests/pkgs.nix`
+
+______________________________________________________________________
+
+Author: Arthur
+Date: 2026-05-17
+PR: #<pending>

--- a/docs/internal/designs/README.md
+++ b/docs/internal/designs/README.md
@@ -51,9 +51,10 @@ If an ADR is superseded, add cross-links in both directions.
 
 ## Index
 
-| #   | Title                                                          | Status   |
-| --- | -------------------------------------------------------------- | -------- |
-| 036 | [Unified `just cut` Release Recipe](036-cut-release-recipe.md) | Accepted |
+| #   | Title                                                                            | Status   |
+| --- | -------------------------------------------------------------------------------- | -------- |
+| 036 | [Unified `just cut` Release Recipe](036-cut-release-recipe.md)                   | Accepted |
+| 037 | [Bump Python Default Interpreter to 3.14](037-python-314-default-interpreter.md) | Proposed |
 
 ## Template
 

--- a/docs/internal/designs/README.md
+++ b/docs/internal/designs/README.md
@@ -54,7 +54,7 @@ If an ADR is superseded, add cross-links in both directions.
 | #   | Title                                                                            | Status   |
 | --- | -------------------------------------------------------------------------------- | -------- |
 | 036 | [Unified `just cut` Release Recipe](036-cut-release-recipe.md)                   | Accepted |
-| 037 | [Bump Python Default Interpreter to 3.14](037-python-314-default-interpreter.md) | Proposed |
+| 037 | [Bump Python Default Interpreter to 3.14](037-python-314-default-interpreter.md) | Accepted |
 
 ## Template
 

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,7 @@
           cargo = nautilusRustToolchain;
           rustc = nautilusRustToolchain;
         };
+        nautilusTraderDefaultPython = pkgs.python314;
         # Make flake lib available for tests
         flakeLib = inputs.nixpkgs.lib.extend (
           final: prev: jackLib
@@ -126,7 +127,7 @@
             cargo = nautilusRustToolchain;
             rustc = nautilusRustToolchain;
             rustPlatform = nautilusRustPlatform;
-            python312 = pkgs.python314;
+            python312 = nautilusTraderDefaultPython;
           };
           seedtool-cli = pkgs.callPackage ./pkgs/seedtool-cli {};
           spooktacular = pkgs.callPackage ./pkgs/spooktacular {

--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,7 @@
             cargo = nautilusRustToolchain;
             rustc = nautilusRustToolchain;
             rustPlatform = nautilusRustPlatform;
+            python312 = pkgs.python314;
           };
           seedtool-cli = pkgs.callPackage ./pkgs/seedtool-cli {};
           spooktacular = pkgs.callPackage ./pkgs/spooktacular {

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,7 @@
           cargo = nautilusRustToolchain;
           rustc = nautilusRustToolchain;
         };
-        nautilusTraderDefaultPython = pkgs.python314;
+        nautilusTraderPython314 = pkgs.python314;
         # Make flake lib available for tests
         flakeLib = inputs.nixpkgs.lib.extend (
           final: prev: jackLib
@@ -127,7 +127,9 @@
             cargo = nautilusRustToolchain;
             rustc = nautilusRustToolchain;
             rustPlatform = nautilusRustPlatform;
-            python312 = nautilusTraderDefaultPython;
+            # Keep the legacy override parameter for `.override { python312 = ...; }` callers.
+            # The default value now comes from Python 3.14.
+            python312 = nautilusTraderPython314;
           };
           seedtool-cli = pkgs.callPackage ./pkgs/seedtool-cli {};
           spooktacular = pkgs.callPackage ./pkgs/spooktacular {

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,6 @@
           cargo = nautilusRustToolchain;
           rustc = nautilusRustToolchain;
         };
-        nautilusTraderPython314 = pkgs.python314;
         # Make flake lib available for tests
         flakeLib = inputs.nixpkgs.lib.extend (
           final: prev: jackLib
@@ -129,7 +128,7 @@
             rustPlatform = nautilusRustPlatform;
             # Keep the legacy override parameter for `.override { python312 = ...; }` callers.
             # The default value now comes from Python 3.14.
-            python312 = nautilusTraderPython314;
+            python312 = pkgs.python314;
           };
           seedtool-cli = pkgs.callPackage ./pkgs/seedtool-cli {};
           spooktacular = pkgs.callPackage ./pkgs/spooktacular {

--- a/modules/flake-parts/python.nix
+++ b/modules/flake-parts/python.nix
@@ -193,8 +193,8 @@ in {
       options.jackpkgs.python = {
         pythonPackage = mkOption {
           type = types.package;
-          default = config.jackpkgs.pkgs.python312;
-          defaultText = "config.jackpkgs.pkgs.python312";
+          default = config.jackpkgs.pkgs.python314;
+          defaultText = "config.jackpkgs.pkgs.python314";
           description = "Python package to use as base interpreter.";
         };
       };

--- a/modules/flake-parts/python.nix
+++ b/modules/flake-parts/python.nix
@@ -414,7 +414,6 @@ in {
             else defaultRoot;
           overlayArgs = {root = finalRoot;} // lib.optionalAttrs (members != null) {inherit members;};
           editableSet = pythonSet.overrideScope (workspace.mkEditablePyprojectOverlay overlayArgs);
-        in let
           env = addMainProgram (editableSet.mkVirtualEnv name finalSpec);
         in
           if ignoreCollisions != []

--- a/pkgs/nautilus-trader/default.nix
+++ b/pkgs/nautilus-trader/default.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   pythonPackage ? null,
+  # Historical argument name kept for `.override { python312 = ...; }` compatibility.
+  # `flake.nix` now wires this to `pkgs.python314`, so the default build still uses Python 3.14.
   python312,
   rustPlatform,
   cargo,

--- a/pkgs/nautilus-trader/default.nix
+++ b/pkgs/nautilus-trader/default.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   pythonPackage ? null,
-  python312 ? null,
-  python314,
+  python312,
   rustPlatform,
   cargo,
   rustc,
@@ -25,9 +24,7 @@
   python_ =
     if pythonPackage != null
     then pythonPackage
-    else if python312 != null
-    then python312
-    else python314;
+    else python312;
 in
   stdenv.mkDerivation {
     pname = "nautilus-trader";

--- a/pkgs/nautilus-trader/default.nix
+++ b/pkgs/nautilus-trader/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   pythonPackage ? null,
-  python312,
+  python314,
   rustPlatform,
   cargo,
   rustc,
@@ -24,7 +24,7 @@
   python_ =
     if pythonPackage != null
     then pythonPackage
-    else python312;
+    else python314;
 in
   stdenv.mkDerivation {
     pname = "nautilus-trader";

--- a/pkgs/nautilus-trader/default.nix
+++ b/pkgs/nautilus-trader/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   pythonPackage ? null,
+  python312 ? null,
   python314,
   rustPlatform,
   cargo,
@@ -24,6 +25,8 @@
   python_ =
     if pythonPackage != null
     then pythonPackage
+    else if python312 != null
+    then python312
     else python314;
 in
   stdenv.mkDerivation {

--- a/tests/pkgs.nix
+++ b/tests/pkgs.nix
@@ -54,10 +54,10 @@
         // {
           _jackpkgsTestMarker = "overlayed-direnv";
         };
-      python312 =
-        pkgs.python312
+      python314 =
+        pkgs.python314
         // {
-          _jackpkgsTestMarker = "overlayed-python312";
+          _jackpkgsTestMarker = "overlayed-python314";
         };
     };
 in {
@@ -167,7 +167,7 @@ in {
     ];
   in {
     expr = perSystem.jackpkgs.python.pythonPackage._jackpkgsTestMarker or null;
-    expected = "overlayed-python312";
+    expected = "overlayed-python314";
   };
 
   # ============================================================


### PR DESCRIPTION
Summary\n- Bump the default jackpkgs Python interpreter to 3.14.\n- Update the nautilus-trader package default to follow the new interpreter baseline.\n- Record the change in a new ADR and update the module docs/tests.\n\nTest plan\n- nix fmt -L\n- nix flake check -L\n\nNotes\n- The PR includes a small amount of treefmt-driven churn in existing files so the repo’s formatting gate stays green.\n- Existing override hooks remain in place for consumers that need a different interpreter.\n\nRisks\n- Downstream consumers pinned to 3.12/3.13 will need to override the default explicitly.\n- The change is intentionally limited to defaults; it does not remove support for older interpreters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Python interpreter from 3.12 to 3.14 for `jackpkgs.python` and a package default, which may break downstream consumers that implicitly relied on 3.12 behavior until they override the interpreter.
> 
> **Overview**
> **Bumps the default Python baseline to 3.14.** The `jackpkgs.python.pythonPackage` option now defaults to `pkgs.python314`, and documentation is updated to reflect the new default.
> 
> Updates `nautilus-trader` to follow the new default interpreter while preserving the legacy `python312` override argument for existing callers, and adjusts module tests/ADRs to lock in the new baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e4be8dbaf905ee3abc6ea7a497341363eb63124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->