### PR TITLE
python: add declarative per-package build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
     - `pyprojectPath` (str, default `./pyproject.toml`)
     - `uvLockPath` (str, default `./uv.lock`)
     - `workspaceRoot` (str, default `.`)
-    - `pythonPackage` (package, default `config.jackpkgs.pkgs.python312`)
+    - `pythonPackage` (package, default `config.jackpkgs.pkgs.python314`)
     - `sourcePreference` ("wheel" | "sdist", default "wheel")
     - `setuptools.packages` (list of str; compatibility shim for adding `setuptools` to `nativeBuildInputs`)
     - `buildFixes` (attrset keyed by locked package name; each entry supports `pythonNativeBuildInputs = [ "meson-python" "meson" "ninja" ]` and `nativeBuildInputs = [ pkgs.bison pkgs.flex ]`)

--- a/README.md
+++ b/README.md
@@ -355,9 +355,10 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
     - `pyprojectPath` (str, default `./pyproject.toml`)
     - `uvLockPath` (str, default `./uv.lock`)
     - `workspaceRoot` (str, default `.`)
-    - `pythonPackage` (package, default `config.jackpkgs.pkgs.python314`)
+    - `pythonPackage` (package, default `config.jackpkgs.pkgs.python312`)
     - `sourcePreference` ("wheel" | "sdist", default "wheel")
-    - `setuptools.packages` (list of str)
+    - `setuptools.packages` (list of str; compatibility shim for adding `setuptools` to `nativeBuildInputs`)
+    - `buildFixes` (attrset keyed by locked package name; each entry supports `pythonNativeBuildInputs = [ "meson-python" "meson" "ninja" ]` and `nativeBuildInputs = [ pkgs.bison pkgs.flex ]`)
     - `environments` (attrset of env defs: `{ name, spec, editable, editableRoot, members, passthru, includeGroups }`)
       - **`spec`**: optional - explicit dependency specification for customization (overrides all other spec options)
       - **`includeGroups`**: nullable bool (default `null`) - include all `[dependency-groups]` (PEP 735) and `[tool.uv.dev-dependencies]` from workspace members.

--- a/flake.nix
+++ b/flake.nix
@@ -285,6 +285,9 @@
             pulumi = import ./tests/pulumi.nix {
               inherit inputs lib;
             };
+            python-package-fixes = import ./tests/python-package-fixes.nix {
+              inherit lib;
+            };
           };
         };
 

--- a/lib/python-package-fixes.nix
+++ b/lib/python-package-fixes.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  packageFixes ? {},
+  setuptoolsPackages ? [],
+}: final: prev: let
+  packageNames = lib.unique (builtins.attrNames packageFixes ++ setuptoolsPackages);
+
+  resolvePythonPackage = packageName: depName:
+    if builtins.hasAttr depName final
+    then builtins.getAttr depName final
+    else throw "jackpkgs.python.buildFixes.${packageName}.pythonNativeBuildInputs references unknown Python package '${depName}'";
+
+  mkFix = packageName: let
+    explicit = packageFixes.${packageName} or {};
+  in {
+    pythonNativeBuildInputs = lib.unique (
+      (lib.optional (builtins.elem packageName setuptoolsPackages) "setuptools")
+      ++ (explicit.pythonNativeBuildInputs or [])
+    );
+    nativeBuildInputs = explicit.nativeBuildInputs or [];
+  };
+
+  overridePackage = packageName:
+    if !(builtins.hasAttr packageName prev)
+    then null
+    else let
+      fix = mkFix packageName;
+      resolvedPythonNativeBuildInputs = map (resolvePythonPackage packageName) fix.pythonNativeBuildInputs;
+    in
+      lib.nameValuePair packageName (prev.${packageName}.overrideAttrs (old: {
+        nativeBuildInputs =
+          (old.nativeBuildInputs or [])
+          ++ resolvedPythonNativeBuildInputs
+          ++ fix.nativeBuildInputs;
+      }));
+
+  pairs = builtins.filter (pair: pair != null) (map overridePackage packageNames);
+in
+  builtins.listToAttrs pairs

--- a/modules/flake-parts/python.nix
+++ b/modules/flake-parts/python.nix
@@ -61,7 +61,44 @@ in {
       setuptools.packages = mkOption {
         type = types.listOf types.str;
         default = ["peewee" "multitasking" "sgmllib3k"];
-        description = "Packages that need setuptools added to nativeBuildInputs.";
+        description = "Packages that need setuptools added to nativeBuildInputs. Retained as a compatibility shim around jackpkgs.python.buildFixes.";
+      };
+
+      buildFixes = mkOption {
+        type = types.attrsOf (types.submodule ({...}: {
+          options = {
+            pythonNativeBuildInputs = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = ''
+                Python packages from the uv2nix package set to append to nativeBuildInputs
+                for this locked dependency. Use package attribute names such as
+                "meson-python", "meson", or "ninja".
+              '';
+            };
+
+            nativeBuildInputs = mkOption {
+              type = types.listOf types.unspecified;
+              default = [];
+              description = ''
+                Additional native build inputs from nixpkgs to append to nativeBuildInputs
+                for this locked dependency.
+              '';
+            };
+          };
+        }));
+        default = {};
+        description = ''
+          Declarative per-package source-build fixes for locked Python dependencies.
+          Use this when a dependency falls back to sdist and needs extra Python build
+          backends or native tools beyond what upstream metadata declares.
+        '';
+        example = {
+          beancount = {
+            pythonNativeBuildInputs = ["meson-python" "meson" "ninja"];
+            nativeBuildInputs = ["<pkgs.bison>" "<pkgs.flex>"];
+          };
+        };
       };
 
       # Environment definitions
@@ -304,20 +341,11 @@ in {
           sourcePreference = cfg.sourcePreference;
         };
 
-        # Extension: Setuptools override overlay for packages with broken/missing build deps
-        # Not documented in uv2nix, but necessary workaround for upstream packaging issues
-        # Some packages don't properly declare setuptools in their build-system dependencies
-        ensureSetuptools = final: prev: let
-          add = name:
-            if builtins.hasAttr name prev
-            then
-              lib.nameValuePair name (prev.${name}.overrideAttrs (old: {
-                nativeBuildInputs = (old.nativeBuildInputs or []) ++ [final.setuptools];
-              }))
-            else null;
-          pairs = builtins.filter (x: x != null) (map add cfg.setuptools.packages);
-        in
-          builtins.listToAttrs pairs;
+        packageFixOverlay = import ../../lib/python-package-fixes.nix {
+          inherit lib;
+          packageFixes = cfg.buildFixes;
+          setuptoolsPackages = cfg.setuptools.packages;
+        };
 
         # Build system overlay should match sourcePreference (wheel OR sdist, not both)
         # Per uv2nix docs: "The build system overlay has the same sdist/wheel distinction as mkPyprojectOverlay"
@@ -328,7 +356,7 @@ in {
             then [jackpkgsInputs.pyproject-build-systems.overlays.wheel]
             else [jackpkgsInputs.pyproject-build-systems.overlays.sdist]
           )
-          ++ [ensureSetuptools]
+          ++ [packageFixOverlay]
           ++ cfg.extraOverlays;
 
         pythonSet = pythonBase.overrideScope (lib.composeManyExtensions overlayList);

--- a/modules/flake-parts/python.nix
+++ b/modules/flake-parts/python.nix
@@ -93,12 +93,14 @@ in {
           Use this when a dependency falls back to sdist and needs extra Python build
           backends or native tools beyond what upstream metadata declares.
         '';
-        example = {
-          beancount = {
-            pythonNativeBuildInputs = ["meson-python" "meson" "ninja"];
-            nativeBuildInputs = ["<pkgs.bison>" "<pkgs.flex>"];
-          };
-        };
+        example = lib.literalExpression ''
+          {
+            beancount = {
+              pythonNativeBuildInputs = [ "meson-python" "meson" "ninja" ];
+              nativeBuildInputs = [ pkgs.bison pkgs.flex ];
+            };
+          }
+        '';
       };
 
       # Environment definitions

--- a/tests/python-package-fixes.nix
+++ b/tests/python-package-fixes.nix
@@ -1,0 +1,67 @@
+{lib}: let
+  mkOverlay = args: import ../lib/python-package-fixes.nix ({inherit lib;} // args);
+
+  mkPackage = old: {
+    overrideAttrs = f: f old;
+  };
+
+  final = {
+    setuptools = "setuptools-pkg";
+    meson-python = "meson-python-pkg";
+    meson = "meson-pkg";
+    ninja = "ninja-pkg";
+  };
+
+  prev = {
+    beancount = mkPackage {
+      nativeBuildInputs = ["existing-native"];
+    };
+
+    peewee = mkPackage {
+      nativeBuildInputs = [];
+    };
+  };
+in {
+  testBuildFixesAppendPythonAndNativeBuildInputs = let
+    overlay = mkOverlay {
+      packageFixes.beancount = {
+        pythonNativeBuildInputs = ["meson-python" "meson" "ninja"];
+        nativeBuildInputs = ["bison-pkg" "flex-pkg"];
+      };
+    };
+    fixed = overlay final prev;
+  in {
+    expr = fixed.beancount.nativeBuildInputs;
+    expected = [
+      "existing-native"
+      "meson-python-pkg"
+      "meson-pkg"
+      "ninja-pkg"
+      "bison-pkg"
+      "flex-pkg"
+    ];
+  };
+
+  testLegacySetuptoolsPackagesBecomeBuildFixes = let
+    overlay = mkOverlay {
+      packageFixes = {};
+      setuptoolsPackages = ["peewee"];
+    };
+    fixed = overlay final prev;
+  in {
+    expr = fixed.peewee.nativeBuildInputs;
+    expected = ["setuptools-pkg"];
+  };
+
+  testMissingTargetPackageIsIgnored = let
+    overlay = mkOverlay {
+      packageFixes.absent = {
+        pythonNativeBuildInputs = ["meson-python"];
+      };
+    };
+    fixed = overlay final prev;
+  in {
+    expr = fixed ? absent;
+    expected = false;
+  };
+}


### PR DESCRIPTION
Summary
- add `jackpkgs.python.buildFixes` for declarative per-package source-build fixes
- keep `setuptools.packages` as a compatibility shim on top of the new overlay helper
- add nix-unit coverage for Python package fix overlay behavior and document the new option in the README

Why
Python 3.14 pushes some locked dependencies onto the sdist path. `beancount==3.2.0` is one of them, and its Meson-backed source build needs extra Python build backends plus native tools that are not always declared upstream. This PR makes that fix path reusable in jackpkgs instead of forcing consumer-local overlays.

Implementation
- extract package-fix overlay logic into `lib/python-package-fixes.nix`
- wire `jackpkgs.python.buildFixes.<package>.pythonNativeBuildInputs` into the uv2nix package set overlay
- wire `jackpkgs.python.buildFixes.<package>.nativeBuildInputs` into the same override
- preserve existing `setuptools.packages` behavior by translating it into the new helper
- correct the README's stale `pythonPackage` default from `python314` to `python312`

Example
```nix
jackpkgs.python.buildFixes.beancount = {
  pythonNativeBuildInputs = ["meson-python" "meson" "ninja"];
  nativeBuildInputs = [pkgs.bison pkgs.flex];
};
```

Test plan
- `nix fmt`
- `nix build .#checks.$(nix eval --impure --expr builtins.currentSystem --raw).nix-unit -L`

Risks
- `buildFixes` is intentionally narrow for now. It only appends to `nativeBuildInputs`, split between Python-package names and nixpkgs packages.
- This does not itself prove that `beancount` now builds on Python 3.14 in a consumer repo. It provides the reusable API needed to express that fix upstream.

Refs
- jmmaloney4/jackpkgs#272
- jmmaloney4/garden#610

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Python package-set overlay that mutates `nativeBuildInputs`, which can affect reproducibility and build outcomes for locked dependencies if misconfigured.
> 
> **Overview**
> Introduces **declarative per-package source-build fixes** for uv2nix-locked Python dependencies via a new `jackpkgs.python.buildFixes` option, allowing both extra *Python build backends* (`pythonNativeBuildInputs`) and *nixpkgs tools* (`nativeBuildInputs`) to be appended during package builds.
> 
> Extracts the previous ad-hoc setuptools workaround into `lib/python-package-fixes.nix`, keeps `setuptools.packages` as a compatibility shim on top of the new mechanism, wires the overlay into `modules/flake-parts/python.nix`, adds nix-unit coverage for the overlay behavior, and documents the new option in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee7a71bf504eb57ac946afa37bd71c3c5ec46f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->