### PR TITLE
refactor(nodejs): converge workspace runtime setup across checks and pre-commit

### DIFF
--- a/docs/internal/designs/040-node-workspace-runtime-convergence.md
+++ b/docs/internal/designs/040-node-workspace-runtime-convergence.md
@@ -1,0 +1,108 @@
+# ADR-040: Converge Node Workspace Runtime Setup Across `checks` and `pre-commit`
+
+## Status
+
+Proposed
+
+## Context
+
+- `jackpkgs` currently has three separate ways to prepare a Node workspace for quality gates:
+  - `modules/flake-parts/checks.nix`
+  - `modules/flake-parts/pre-commit.nix`
+  - `modules/flake-parts/just.nix`
+- All three need the same underlying contract: take a captured `nodeModules` derivation, recreate a writable workspace-shaped runtime in a sandbox or repo checkout, expose `.bin` tools on `PATH`, and preserve pnpm workspace resolution semantics.
+- That contract was never made explicit. Instead, each module grew its own shell fragments and local assumptions.
+- ADR-023 returned the repo to pnpm. ADR-028 expanded the `nodeModules` output contract so workspace-local `node_modules` directories can exist under `$out/<workspace>/node_modules/`.
+- Recent failures in `garden` exposed the architectural gap:
+  - `pre-commit.nix` linked root `node_modules` as a single symlink into the read-only store.
+  - `checks.nix` had already evolved a writable symlink-forest strategy plus package-local `node_modules` linking.
+  - As a result, `checks` passed while `pre-commit` failed on the same workspace with `Permission denied` creating `node_modules/<workspace>` symlinks and later with missing package-local dependencies such as `@pulumi/cloudflare`.
+- The immediate bug can be patched in each consumer, but that leaves the real problem in place: duplicated runtime setup logic with divergent behavior.
+- The repo already has a broader preference for generated shell helpers over ad hoc repeated shell fragments. ADR-038 is the current example of taking a repeated pattern and giving it one canonical interface.
+
+## Decision
+
+- `jackpkgs` MUST define a single reusable helper for the "captured pnpm workspace runtime" contract in `lib/nodejs-helpers.nix`.
+- `checks.nix` and `pre-commit.nix` MUST consume that helper instead of maintaining separate shell implementations for:
+  - writable root `node_modules` population
+  - package-local `node_modules` linking
+  - workspace package symlink creation
+  - `.bin` PATH setup
+- The shared helper MUST preserve the output contract established by ADR-028:
+  - root dependencies come from `$out/node_modules`
+  - package-local dependencies may come from `$out/<workspace>/node_modules`
+- The first convergence phase is limited to `checks.nix` and `pre-commit.nix`. `just.nix` is intentionally deferred because it runs in the devshell against a live checkout rather than against a captured `nodeModules` derivation.
+- `just.nix` SHOULD converge on the same conceptual runtime contract later, but this ADR does not require forcing it through the same helper before that contract is designed cleanly.
+- New Node quality-gate features MUST extend the shared helper or an adjacent shared abstraction rather than copying shell setup into another module.
+
+## Consequences
+
+### Benefits
+
+- One runtime contract instead of parallel shell snippets that drift silently.
+- `checks` and `pre-commit` now fail or succeed for the same reasons on the same workspace topology.
+- Fixes to pnpm sandbox semantics land once and propagate to all consumers.
+- Test coverage can assert the shared behavior instead of freezing two slightly different implementations.
+- The codebase is easier to reason about because the architectural boundary is explicit: "captured nodeModules output" vs "consumer-specific command execution."
+
+### Trade-offs
+
+- The shared helper increases coupling between `checks.nix` and `pre-commit.nix`, but that coupling already exists in reality; the ADR makes it explicit.
+- We are not fully unifying `just.nix` in the first pass, so some architectural asymmetry remains.
+- The helper still emits shell, so this is a bounded refactor, not a total redesign of Node tool execution.
+
+### Risks & Mitigations
+
+- Risk: The helper may accidentally encode assumptions that only hold for one consumer.
+  - Mitigation: Keep the helper scoped to runtime preparation only. Leave command invocation, error messaging, and check-specific policy in the caller.
+- Risk: Future work reintroduces local shell snippets in a hurry.
+  - Mitigation: Treat this ADR as the design guardrail; new Node sandbox setup belongs in the shared helper.
+- Risk: `just.nix` remains a third execution model and drifts further.
+  - Mitigation: Track a follow-up to decide whether `just.nix` should consume a parallel helper, stay intentionally separate, or move to generated shell applications.
+
+## Alternatives Considered
+
+### Alternative A — Keep patching each module independently
+
+- Pros: Fastest path for the immediate bug.
+- Cons: Guarantees future drift, duplicates fixes, and makes failures harder to reason about.
+- Why not chosen: This is the architecture that produced the current regression.
+
+### Alternative B — Force all consumers through one giant Node execution framework now
+
+- Pros: Maximum unification in theory.
+- Cons: Higher blast radius, slower review, mixes runtime setup with unrelated command-generation policy, and would pull `just.nix` into the refactor before its constraints are cleanly modeled.
+- Why not chosen: Too much change for the current bug class. The bounded helper gets most of the architectural win with lower risk.
+
+### Alternative C — Reconstruct pnpm links dynamically in each caller
+
+- Pros: Keeps the helper layer thin or nonexistent.
+- Cons: Repeats pnpm runtime assumptions in multiple places and recreates the same divergence problem under a different name.
+- Why not chosen: We already have the captured derivation contract from ADR-028. Consumers should use it consistently, not reinterpret it independently.
+
+## Implementation Plan
+
+1. Add a shared `mkWorkspaceRuntime` helper to `lib/nodejs-helpers.nix`.
+2. Port `checks.nix` to use the helper for root and package-local `node_modules` setup.
+3. Port `pre-commit.nix` to use the same helper for biome, `tsc`, and vitest hooks.
+4. Update nix-unit tests so they assert the converged runtime contract instead of stale implementation details.
+5. Keep `just.nix` unchanged in this phase, but record the remaining design choice explicitly in the plan document and any follow-up PR notes.
+6. In a later phase, decide whether `pre-commit` hook wrappers should move to `writeShellApplication`-backed generation consistent with ADR-038-style shell encapsulation.
+
+## Related
+
+- `docs/internal/plans/2026-05-19-node-tooling-sandbox-convergence.md`
+- ADR-023: `docs/internal/designs/023-return-to-pnpm.md`
+- ADR-028: `docs/internal/designs/028-pnpm-workspace-node-modules-capture.md`
+- ADR-029: `docs/internal/designs/029-unified-quality-gate-controls.md`
+- ADR-038: `docs/internal/designs/038-mk-helm-chart-from-github.md`
+- `lib/nodejs-helpers.nix`
+- `modules/flake-parts/checks.nix`
+- `modules/flake-parts/pre-commit.nix`
+- `modules/flake-parts/just.nix`
+
+______________________________________________________________________
+
+Author: Jack Maloney
+Date: 2026-05-19
+PR: <pending>

--- a/docs/internal/designs/README.md
+++ b/docs/internal/designs/README.md
@@ -57,6 +57,7 @@ If an ADR is superseded, add cross-links in both directions.
 | 037 | [Bump Python Default Interpreter to 3.14](037-python-314-default-interpreter.md) | Accepted |
 | 038 | [mkHelmChartFromGitHub Helper](038-mk-helm-chart-from-github.md)                   | Accepted |
 | 039 | [Shellcheck for Generated Pre-commit Hook Scripts](039-shellcheck-pre-commit-hooks.md) | Accepted |
+| 040 | [Converge Node Workspace Runtime Setup Across `checks` and `pre-commit`](040-node-workspace-runtime-convergence.md) | Proposed |
 
 ## Template
 

--- a/lib/nodejs-helpers.nix
+++ b/lib/nodejs-helpers.nix
@@ -166,5 +166,53 @@ in {
     findNodeModulesRoot = rootVar: storePath: ''
       ${rootVar}="${storePath}/node_modules"
     '';
+
+    mkWorkspaceRuntime = {
+      nodeModules,
+      workspaceRoot,
+      packages,
+    }: let
+      nmStore = lib.escapeShellArg (toString nodeModules);
+    in ''
+      nm_store=${nmStore}
+      nm_root="$nm_store/node_modules"
+      if [ -z "$nm_root" ]; then
+        echo "ERROR: Unable to find node_modules in $nm_store" >&2
+        echo "Expected: node_modules/ at the derivation root" >&2
+        exit 1
+      fi
+
+      mkdir -p node_modules
+      shopt -s dotglob
+      for entry in "$nm_root"/*/; do
+        entry_name="$(basename "$entry")"
+        if [[ "$entry_name" == @* ]]; then
+          mkdir -p "node_modules/$entry_name"
+          for scoped_pkg in "$entry"*/; do
+            ln -sfn "$scoped_pkg" "node_modules/$entry_name/$(basename "$scoped_pkg")"
+          done
+        else
+          ln -sfn "$entry" "node_modules/$entry_name"
+        fi
+      done
+      shopt -u dotglob
+
+      ${lib.concatMapStringsSep "\n" (pkg: ''
+          mkdir -p ${lib.escapeShellArg pkg}
+          if [ -d "$nm_store"/${lib.escapeShellArg pkg}/node_modules ]; then
+            ln -sfn "$nm_store"/${lib.escapeShellArg pkg}/node_modules ${lib.escapeShellArg pkg}/node_modules
+          elif [ -d "$nm_root"/${lib.escapeShellArg pkg}/node_modules ]; then
+            ln -sfn "$nm_root"/${lib.escapeShellArg pkg}/node_modules ${lib.escapeShellArg pkg}/node_modules
+          fi
+        '')
+        packages}
+
+      ${mkWorkspaceSymlinks workspaceRoot packages}
+
+      nm_bin="$nm_store/node_modules/.bin"
+      if [ -n "$nm_bin" ]; then
+        export PATH="$nm_bin:$PATH"
+      fi
+    '';
   };
 }

--- a/lib/nodejs-helpers.nix
+++ b/lib/nodejs-helpers.nix
@@ -171,19 +171,17 @@ in {
       nodeModules,
       workspaceRoot,
       packages,
-    }: let
-      nmStore = lib.escapeShellArg (toString nodeModules);
-    in ''
-      nm_store=${nmStore}
+    }: ''
+      nm_store="${nodeModules}"
       nm_root="$nm_store/node_modules"
-      if [ -z "$nm_root" ]; then
+      if [ ! -d "$nm_root" ]; then
         echo "ERROR: Unable to find node_modules in $nm_store" >&2
         echo "Expected: node_modules/ at the derivation root" >&2
         exit 1
       fi
 
       mkdir -p node_modules
-      shopt -s dotglob
+      shopt -s dotglob nullglob
       for entry in "$nm_root"/*/; do
         entry_name="$(basename "$entry")"
         if [[ "$entry_name" == @* ]]; then
@@ -195,7 +193,7 @@ in {
           ln -sfn "$entry" "node_modules/$entry_name"
         fi
       done
-      shopt -u dotglob
+      shopt -u dotglob nullglob
 
       ${lib.concatMapStringsSep "\n" (pkg: ''
           mkdir -p ${lib.escapeShellArg pkg}
@@ -210,7 +208,7 @@ in {
       ${mkWorkspaceSymlinks workspaceRoot packages}
 
       nm_bin="$nm_store/node_modules/.bin"
-      if [ -n "$nm_bin" ]; then
+      if [ -d "$nm_bin" ]; then
         export PATH="$nm_bin:$PATH"
       fi
     '';

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -437,64 +437,15 @@ in {
           touch $out
         '';
 
-      # Link node_modules into the sandbox
-      # Strategy: link root node_modules, then link per-package node_modules when present.
-      # Expected layout from nodejs output derivation:
-      # - root: <store>/node_modules
-      # - workspace package: <store>/<pkg>/node_modules
       linkNodeModules = nodeModules: packages:
         if nodeModules == null
         then ""
         else ''
-          nm_store=${nodeModules}
-          echo "Linking node_modules from $nm_store..."
-
-          # Resolve node_modules root from output derivation
-          ${jackpkgsLib.nodejs.findNodeModulesRoot "nm_root" "$nm_store"}
-
-          if [ -z "$nm_root" ]; then
-            echo "ERROR: Unable to find node_modules in $nm_store" >&2
-            echo "Expected: node_modules/ at the derivation root" >&2
-            echo "Enable Node.js module or provide custom nodeModules via jackpkgs.checks.typescript.tsc.nodeModules" >&2
-            exit 1
-          fi
-
-          # Create a writable node_modules directory populated with symlinks into the
-          # store.  A single symlink to the read-only store would prevent
-          # mkWorkspaceSymlinks from later running `mkdir -p node_modules/@scope`.
-          # Use dotglob so hidden entries like .bin are included.
-          mkdir -p node_modules
-          shopt -s dotglob
-          for entry in "$nm_root"/*/; do
-            entry_name="$(basename "$entry")"
-            if [[ "$entry_name" == @* ]]; then
-              # Scoped package directory: link each package inside the scope individually
-              # so that the scope directory itself remains writable.
-              mkdir -p "node_modules/$entry_name"
-              for scoped_pkg in "$entry"*/; do
-                ln -sfn "$scoped_pkg" "node_modules/$entry_name/$(basename "$scoped_pkg")"
-              done
-            else
-              ln -sfn "$entry" "node_modules/$entry_name"
-            fi
-          done
-          shopt -u dotglob
-
-          # Link package-level node_modules
-          ${lib.concatMapStringsSep "\n" (pkg: ''
-              mkdir -p ${lib.escapeShellArg pkg}
-
-              # Link nested node_modules for workspace packages.
-              # Workspace-level node_modules are captured under the derivation root
-              # (e.g. <store>/packages/foo/node_modules), not under root node_modules.
-              if [ -d "$nm_store"/${lib.escapeShellArg pkg}/node_modules ]; then
-                ln -sfn "$nm_store"/${lib.escapeShellArg pkg}/node_modules ${lib.escapeShellArg pkg}/node_modules
-              elif [ -d "$nm_root"/${lib.escapeShellArg pkg}/node_modules ]; then
-                # Backward-compatible fallback for custom layouts
-                ln -sfn "$nm_root"/${lib.escapeShellArg pkg}/node_modules ${lib.escapeShellArg pkg}/node_modules
-              fi
-            '')
-            packages}
+          echo "Linking node_modules from ${toString nodeModules}..."
+          ${jackpkgsLib.nodejs.mkWorkspaceRuntime {
+            inherit nodeModules packages;
+            workspaceRoot = projectRoot;
+          }}
         '';
 
       # ============================================================

--- a/modules/flake-parts/pre-commit.nix
+++ b/modules/flake-parts/pre-commit.nix
@@ -319,65 +319,15 @@ in {
           then map jackpkgsLib.validateWorkspacePath checksCfg.biome.lint.packages
           else discoverPnpmPackages projectRoot;
 
-        # Create a writable node_modules directory populated with symlinks into
-        # the store.  Mirrors the linkNodeModules strategy in checks.nix: a
-        # single symlink to the read-only store would prevent mkWorkspaceSymlinks
-        # from creating workspace package symlinks (mkdir -p node_modules/@scope
-        # fails inside a read-only symlink target).
-        mkNodeModulesSetup = nodeModules: let
-          nmStore = lib.escapeShellArg (toString nodeModules);
-        in ''
-          nm_store=${nmStore}
-          ${jackpkgsLib.nodejs.findNodeModulesRoot "nm_root" "$nm_store"}
-          if [ -z "$nm_root" ]; then
-            echo "ERROR: Unable to find node_modules in $nm_store" >&2
-            exit 1
-          fi
-          mkdir -p node_modules
-          shopt -s dotglob
-          for entry in "$nm_root"/*/; do
-            entry_name="$(basename "$entry")"
-            if [[ "$entry_name" == @* ]]; then
-              mkdir -p "node_modules/$entry_name"
-              for scoped_pkg in "$entry"*/; do
-                ln -sfn "$scoped_pkg" "node_modules/$entry_name/$(basename "$scoped_pkg")"
-              done
-            else
-              ln -sfn "$entry" "node_modules/$entry_name"
-            fi
-          done
-          shopt -u dotglob
-          ${jackpkgsLib.nodejs.findNodeModulesBin "nm_bin" "$nm_store"}
-          if [ -n "$nm_bin" ]; then
-            export PATH="$nm_bin:$PATH"
-          fi
-        '';
-
-        # Link per-package node_modules from the derivation store.  pnpm
-        # installs package-local dependencies under <store>/<pkg>/node_modules
-        # (e.g. @pulumi/cloudflare lives under deploy/platform/cloudflared/
-        # node_modules, not at the root).  Without these, tsc --noEmit run
-        # inside each package directory cannot resolve its own dependencies.
-        linkPackageNodeModules = nodeModules: packages: let
-          nmStore = lib.escapeShellArg (toString nodeModules);
-        in
-          lib.concatMapStringsSep "\n" (pkg: ''
-            mkdir -p ${lib.escapeShellArg pkg}
-            if [ -d ${nmStore}/${lib.escapeShellArg pkg}/node_modules ]; then
-              ln -sfn ${nmStore}/${lib.escapeShellArg pkg}/node_modules ${lib.escapeShellArg pkg}/node_modules
-            elif [ -d "$nm_root"/${lib.escapeShellArg pkg}/node_modules ]; then
-              ln -sfn "$nm_root"/${lib.escapeShellArg pkg}/node_modules ${lib.escapeShellArg pkg}/node_modules
-            fi
-          '')
-          packages;
-
         biomeLintEntry = lib.getExe (pkgs.writeShellApplication {
           name = "biome-lint-hook";
           runtimeInputs = lib.optionals (biomeNodeModules != null) [biomeNodeModules];
           text = ''
-            ${lib.optionalString (biomeNodeModules != null) (mkNodeModulesSetup biomeNodeModules)}
-            ${lib.optionalString (biomeNodeModules != null) (jackpkgsLib.mkWorkspaceSymlinks projectRoot biomePackages)}
-            ${lib.optionalString (biomeNodeModules != null) (linkPackageNodeModules biomeNodeModules biomePackages)}
+            ${lib.optionalString (biomeNodeModules != null) (jackpkgsLib.nodejs.mkWorkspaceRuntime {
+              nodeModules = biomeNodeModules;
+              workspaceRoot = projectRoot;
+              packages = biomePackages;
+            })}
             if command -v biome >/dev/null 2>&1; then
               BIOME_BIN="biome"
             else
@@ -406,9 +356,11 @@ in {
             name = "tsc-hook";
             runtimeInputs = [tscNodeModules];
             text = ''
-              ${mkNodeModulesSetup tscNodeModules}
-              ${jackpkgsLib.mkWorkspaceSymlinks projectRoot tscPackages}
-              ${linkPackageNodeModules tscNodeModules tscPackages}
+              ${jackpkgsLib.nodejs.mkWorkspaceRuntime {
+                nodeModules = tscNodeModules;
+                workspaceRoot = projectRoot;
+                packages = tscPackages;
+              }}
               ${lib.concatMapStringsSep "\n" (pkg: ''
                   (cd ${lib.escapeShellArg pkg} && "${tscExe}" --noEmit${escapeExtraArgs checksCfg.typescript.tsc.extraArgs})
                 '')
@@ -434,9 +386,11 @@ in {
           name = "vitest-hook";
           runtimeInputs = lib.optionals (vitestNodeModules != null) [vitestNodeModules];
           text = ''
-            ${lib.optionalString (vitestNodeModules != null) (mkNodeModulesSetup vitestNodeModules)}
-            ${lib.optionalString (vitestNodeModules != null) (jackpkgsLib.mkWorkspaceSymlinks projectRoot vitestPackages)}
-            ${lib.optionalString (vitestNodeModules != null) (linkPackageNodeModules vitestNodeModules vitestPackages)}
+            ${lib.optionalString (vitestNodeModules != null) (jackpkgsLib.nodejs.mkWorkspaceRuntime {
+              nodeModules = vitestNodeModules;
+              workspaceRoot = projectRoot;
+              packages = vitestPackages;
+            })}
             if [ -x "./node_modules/.bin/vitest" ]; then
               VITEST_BIN="$(pwd)/node_modules/.bin/vitest"
             elif command -v vitest >/dev/null 2>&1; then

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -700,7 +700,7 @@ in {
   in {
     expr =
       hasInfixAll [
-        "Linking node_modules from $nm_store..."
+        "Linking node_modules from"
         ''mkdir -p node_modules''
         ''shopt -s dotglob''
         ''for entry in "$nm_root"/*/; do''


### PR DESCRIPTION
## Summary

Converge the duplicated Node workspace runtime setup logic across `checks.nix` and `pre-commit.nix` into a single shared helper in `lib/nodejs-helpers.nix`.

> **Rebased onto main** after PR #281 (shellcheck / `writeShellApplication` wrappers) merged. ADR renumbered 039 → 040.

### Problem

`checks.nix` and `pre-commit.nix` both needed to:
1. Create a writable `node_modules` directory populated with symlinks into the Nix store
2. Link per-package workspace `node_modules` (from the ADR-028 output contract)
3. Set up workspace package symlinks for pnpm resolution
4. Expose `.bin` on PATH

Each module grew its own shell fragments for this, and they drifted. The `pre-commit` module used a single read-only symlink to `node_modules` which caused `Permission denied` when tools tried to write into it (e.g. creating cache directories). The `checks` module had already evolved a writable symlink-forest strategy. Same workspace, different failure modes.

### What changed

- Added `mkWorkspaceRuntime` helper to `lib/nodejs-helpers.nix` that produces the shell setup for a captured pnpm workspace runtime in one call.
- Ported `checks.nix` to use the shared helper for `linkNodeModules` generation.
- Ported `pre-commit.nix` to use the shared helper — now embedded **inside `writeShellApplication` text bodies** from PR #281, replacing the deleted inline shell helpers.
- Preserved PR #281's vitest binary detection order (local `./node_modules/.bin/vitest` first).
- Updated nix-unit test expectations:
  - `tests/checks.nix` updated to match converged output.
  - `tests/pre-commit.nix` updated to use `isStoreExe` assertions (from #281) since `writeShellApplication` produces store paths.
- Recorded the decision as **ADR-040** (renumbered from 039 after PR #281 took ADR-039 for shellcheck).

### What did NOT change

- `just.nix` is intentionally not converged in this PR. It runs in the devshell against a live checkout, not against a captured `nodeModules` derivation. Convergence there is a separate design decision.
- The `nodeModules` derivation output contract (ADR-028) is unchanged.
- The integration test fixtures are unchanged.

## Test plan

- [x] `nix build .#checks.x86_64-linux.nix-unit` — 158/158 tests pass
- [x] `nix build .#checks.x86_64-linux.pnpm-tsc-check` — passes
- [x] `nix build .#checks.x86_64-linux.pnpm-vitest-check` — passes
- [ ] `nix flake check -L` — full check suite (remote builders, may take time)
- [ ] Garden `nix flake check -L` — end-to-end validation with a real consumer repo

## Risks

- The converged helper encodes one runtime contract. If a future consumer needs a different workspace topology, the helper may need extension rather than replacement.
- `just.nix` remains a third execution model. This is acceptable for phase 1 but should be revisited.

## Follow-up

- Decide whether `just.nix` should converge on a related shared abstraction or remain intentionally separate.

## Related

- ADR-040: `docs/internal/designs/040-node-workspace-runtime-convergence.md`
- ADR-039: `docs/internal/designs/039-shellcheck-write-shell-application.md` (PR #281)
- ADR-028: `docs/internal/designs/028-pnpm-workspace-node-modules-capture.md`
- ADR-023: `docs/internal/designs/023-return-to-pnpm.md`
- Plan: `docs/internal/plans/2026-05-19-node-tooling-sandbox-convergence.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Node workspace setup used by CI `checks` and `pre-commit` hooks; regressions could break Node lint/test/typecheck execution across repos despite being largely a refactor.
> 
> **Overview**
> Introduces `jackpkgsLib.nodejs.mkWorkspaceRuntime` to build a writable pnpm workspace runtime from a captured `nodeModules` derivation (root symlink-forest, per-package `node_modules` linking, workspace package symlinks, and `.bin` PATH).
> 
> Refactors `checks.nix` and `pre-commit.nix` (biome/tsc/vitest hook scripts) to use this single helper instead of their duplicated inline shell setup, and adjusts nix-unit expectations to match the new generated script output. Adds ADR-040 and updates the ADR index to document the convergence decision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a295f7994d3c3859eb05a438827ada42faf946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->