### PR TITLE
fix(just): pass level as positional arg in bump/release recipes

### DIFF
--- a/docs/internal/designs/036-cut-release-recipe.md
+++ b/docs/internal/designs/036-cut-release-recipe.md
@@ -81,10 +81,10 @@ replaced with one-line aliases:
 
 ```
 bump:
-    @just cut level="patch"
+    @just cut "patch"
 
 release:
-    @just cut level="minor"
+    @just cut "minor"
 ```
 
 This replaces the current tag-only implementations. Consumers that already use `just bump` or

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -483,11 +483,11 @@ in {
               ""
               "# Bump patch version"
               "bump:"
-              "    @just cut level=\"patch\""
+              "    @just cut \"patch\""
               ""
               "# New minor release"
               "release:"
-              "    @just cut level=\"minor\""
+              "    @just cut \"minor\""
               ""
             ];
           in {

--- a/tests/module-justfiles.nix
+++ b/tests/module-justfiles.nix
@@ -237,11 +237,11 @@ in {
       ""
       "# Bump patch version"
       "bump:"
-      "    @just cut level=\"patch\""
+      "    @just cut \"patch\""
       ""
       "# New minor release"
       "release:"
-      "    @just cut level=\"minor\""
+      "    @just cut \"minor\""
     ]
   );
 }


### PR DESCRIPTION
## Problem

`just bump` and `just release` fail with:

```
Unknown level: level=patch (use patch, minor, or major)
```

## Root cause

In `just`, `@just cut level="patch"` passes the literal string `level=patch` as the
first positional argument to the `cut` recipe — not a keyword argument. The `case`
statement matches on `patch` | `minor` | `major`, so `level=patch` falls through to
the error branch.

## Fix

Change from `@just cut level="patch"` to `@just cut "patch"` (positional arg).

## Files changed

- `modules/flake-parts/just.nix` — generated justfile source
- `tests/module-justfiles.nix` — expected output in test
- `docs/internal/designs/036-cut-release-recipe.md` — design doc

## Validation

- All 158 nix-unit tests pass
- `module-testCutTagOnly`, `module-testCutWithNpm`, `justfile-testRealWorldGeneration` all pass
- treefmt clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small change to generated `just` recipe invocations that fixes an argument-parsing bug and is covered by justfile-generation tests.
> 
> **Overview**
> Fixes `just bump`/`just release` alias recipes (when `cut` is enabled) to pass the release level as a **positional argument** (`@just cut "patch"`/`"minor"`) instead of `level="..."`, which `just` treats as a literal string.
> 
> Updates the design doc example and the expected justfile output in `tests/module-justfiles.nix` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca592827d761927f7a780db2819d8200e81a8542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->