### PR TITLE
feat(nodejs): add ci-pnpm devshell for minimal CI pnpm operations

### DIFF
--- a/modules/flake-parts/nodejs.nix
+++ b/modules/flake-parts/nodejs.nix
@@ -150,12 +150,15 @@ in {
 
       # Minimal CI devshell for pnpm operations (install, build, pack).
       # Follows ADR-013 CI devshell conventions: no inputsFrom, no dev tools,
-      # no interactive shell enhancements.
-      devShells.ci-pnpm = pkgs.mkShell {
+      # no interactive shell enhancements. Uses mkShellNoCC to avoid pulling
+      # in the full C toolchain (gcc, binutils) — node + pnpm don't need it.
+      devShells.ci-pnpm = pkgs.mkShellNoCC {
+        name = "ci-pnpm";
         packages = [
           sysCfg.package
           sysCfg.pnpmPackage
         ];
+        CI = true;
       };
 
       jackpkgs.shell.inputsFrom =

--- a/modules/flake-parts/nodejs.nix
+++ b/modules/flake-parts/nodejs.nix
@@ -148,6 +148,16 @@ in {
         '';
       };
 
+      # Minimal CI devshell for pnpm operations (install, build, pack).
+      # Follows ADR-013 CI devshell conventions: no inputsFrom, no dev tools,
+      # no interactive shell enhancements.
+      devShells.ci-pnpm = pkgs.mkShell {
+        packages = [
+          sysCfg.package
+          sysCfg.pnpmPackage
+        ];
+      };
+
       jackpkgs.shell.inputsFrom =
         lib.optional (config.jackpkgs.outputs.nodejsDevShell != null)
         config.jackpkgs.outputs.nodejsDevShell;


### PR DESCRIPTION
## Summary

When `jackpkgs.nodejs.enable = true`, repos now get a `devShells.ci-pnpm` containing only node and pnpm.

This is needed by the reusable `pnpm.yml` workflow in sector7 (jmmaloney4/sector7), which runs `nix develop .#ci-pnpm --command pnpm install --frozen-lockfile` for lockfile verification and package builds. Currently that workflow fails because no repo defines `ci-pnpm`.

Follows ADR-013 CI devshell conventions: no `inputsFrom`, no dev tools, no interactive shell enhancements.

## Changes

- `modules/flake-parts/nodejs.nix`: add `devShells.ci-pnpm` in the `perSystem` config block, gated by `jackpkgs.nodejs.enable`.

## Test Plan

- [x] `nix flake check --no-build -L` passes
- [x] Verified `ci-pnpm` resolves in sector7 with `nix develop .#ci-pnpm --command echo ok` using local override
- [ ] CI passes (nix-unit, treefmt, pre-commit)
- [ ] Update sector7 flake input to this PR's revision and confirm `_dogfood-pnpm.yml` succeeds

## Risks

- Low. Purely additive; no existing devshells or outputs are modified.
- The devshell is minimal (node + pnpm only) which may not be enough for repos that need additional tools during CI builds. They can extend via `jackpkgs.nodejs.ci.packages` if we add that option later (following the `jackpkgs.pulumi.ci.packages` pattern).

## Follow-up

- Update sector7 `flake.lock` to consume this after merge.
- Consider adding `jackpkgs.nodejs.ci.packages` option for customization (parallels `jackpkgs.pulumi.ci.packages`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely additive devshell output, with no changes to existing build logic or default shells.
> 
> **Overview**
> Adds a new `devShells.ci-pnpm` when `jackpkgs.nodejs.enable` is set, providing a **minimal CI-oriented** Nix devshell that includes only Node (`sysCfg.package`) and pnpm (`sysCfg.pnpmPackage`).
> 
> The new shell uses `pkgs.mkShellNoCC` and sets `CI=true`, intentionally avoiding `inputsFrom` and interactive shell hooks to keep CI environments small and deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2b0aa44ea67d4357f1d49c052fe02d5b62dddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->