### PR TITLE
feat(nodejs): add gh and jq to ci-pnpm devshell

### DIFF
--- a/modules/flake-parts/nodejs.nix
+++ b/modules/flake-parts/nodejs.nix
@@ -157,6 +157,8 @@ in {
         packages = [
           sysCfg.package
           sysCfg.pnpmPackage
+          pkgs.gh
+          pkgs.jq
         ];
         CI = true;
       };


### PR DESCRIPTION
## Problem

The pnpm CI workflow's `analyze` job needs `gh` (for PR comments) and `jq` (for JSON processing). Currently these are installed ad-hoc via `nix profile install` in `pnpm.yml`, which requires a separate `GITHUB_PATH` dance and duplicates the nix mechanism.

## Fix

Add `gh` and `jq` to the `ci-pnpm` devshell in jackpkgs. This way the entire pnpm CI workflow uses a single nix mechanism — `nix develop .#ci-pnpm` — instead of mixing devshells and ad-hoc profile installs.

## Follow-up

After merging, sector7 `pnpm.yml` can drop the `nix profile install` + `GITHUB_PATH` step and use `nix develop .#ci-pnpm` for the analyze job instead.

## Risks

Minimal. Adds ~15MB to the ci-pnpm closure on Linux (gh + jq). All existing consumers get the tools but jobs that don't use them are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends the `ci-pnpm` Nix devshell package set to include `gh` and `jq`, without changing build logic or runtime behavior beyond tool availability.
> 
> **Overview**
> The `ci-pnpm` Nix devshell now includes `pkgs.gh` and `pkgs.jq` alongside Node.js and pnpm, so CI jobs using `nix develop .#ci-pnpm` have GitHub CLI and JSON processing available without separate installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c216da0f9bf83a36f9e3c6ac4988e357875600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->