### PR TITLE
feat: add Pulumi drift report tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ ______________________________________________________________________
 - `docfx` - .NET docs generator
 - `epub2tts` - EPUB -> TTS
 - `lean` - Lean theorem prover
+- `pulumi-drift-report` - Pulumi preview/refresh drift reporter
 - `seedtool-cli` - SSKR seed tool CLI
 - `tod` - Todoist CLI
 

--- a/docs/internal/designs/041-pulumi-drift-report-tool.md
+++ b/docs/internal/designs/041-pulumi-drift-report-tool.md
@@ -1,0 +1,88 @@
+# ADR-041: Pulumi Drift Report Tool
+
+- Status: Proposed
+- Date: 2026-05-24
+- Related: jackpkgs Pulumi package set, downstream Pulumi monorepos
+
+## Context
+
+Several owned repositories use Pulumi stacks spread across multiple project directories. When branch state changes, the useful question is not just "does `pulumi up` want to do work?" but "which resources in which stacks will change if this branch lands?"
+
+Today that answer is scattered across ad hoc local commands. The result is predictable:
+
+- people inspect only one stack and miss the rest
+- preview output is human-oriented and hard to aggregate
+- drift from the provider and changes from the branch get conflated
+- there is no standard report format for CI or local review
+
+We want a small Python tool that can live in jackpkgs, run against a repo checkout, and produce a stack-by-stack report of the resources Pulumi would change.
+
+## Decision
+
+Add a Python CLI package, `pulumi-drift-report`, to jackpkgs.
+
+The tool will:
+
+- discover Pulumi project directories under a given root
+- enumerate the stacks for each project with `pulumi stack ls --json`
+- run a preview/refresh pass for each stack
+- parse Pulumi's JSON output into a stable internal model
+- emit either a human-readable report or JSON
+
+The initial implementation will use the Pulumi CLI via subprocess, not the Automation API.
+
+## Why Python
+
+Python is the simplest fit for this kind of orchestration tool:
+
+- subprocess + JSON parsing are first-class
+- no extra runtime beyond what downstream repos already use for tooling
+- easy to package in jackpkgs and easy to test with fake CLI stubs
+- a PEP 420 namespace package matches the existing `jmmaloney4.tools.*` layout used in `garden`
+
+## Output strategy
+
+Pulumi's JSON preview/refresh output is the right source of truth for machine parsing.
+
+The tool will parse the structured JSON produced by the CLI and reduce it to a smaller report model containing:
+
+- stack identity
+- project path/name
+- preview and refresh summaries
+- per-resource operations that are not `same`
+- command failures, if any
+
+If the CLI version only supports the older JSON event mode, the parser can be extended to ingest JSONL events as a fallback.
+
+## Tradeoffs
+
+### Pros
+
+- keeps the tool small and explicit
+- avoids pulling in Pulumi Automation SDK complexity
+- works for any repo that already uses the CLI
+- produces output that can be used locally and in CI
+
+### Cons
+
+- depends on the Pulumi CLI being installed
+- JSON schema is CLI-version-dependent, so parsing needs to be tolerant
+- the first version will still rely on the user's Pulumi auth and backend setup
+
+## Scope boundary
+
+This tool is for reporting, not remediation.
+
+It will not:
+
+- apply changes
+- refresh state automatically unless explicitly requested
+- try to infer which changes are "good" or "bad"
+- manage secrets or backend configuration
+
+## Follow-up ideas
+
+- add a CI-friendly machine-readable summary file
+- support filtering by stack name or project path
+- optionally group changes by resource type or provider
+- allow a `--changed-files` mode to narrow which projects are scanned

--- a/docs/internal/designs/README.md
+++ b/docs/internal/designs/README.md
@@ -58,6 +58,7 @@ If an ADR is superseded, add cross-links in both directions.
 | 038 | [mkHelmChartFromGitHub Helper](038-mk-helm-chart-from-github.md)                                                    | Accepted |
 | 039 | [Shellcheck for Generated Pre-commit Hook Scripts](039-shellcheck-pre-commit-hooks.md)                              | Accepted |
 | 040 | [Converge Node Workspace Runtime Setup Across `checks` and `pre-commit`](040-node-workspace-runtime-convergence.md) | Proposed |
+| 041 | [Pulumi Drift Report Tool](041-pulumi-drift-report-tool.md)                                                      | Proposed |
 
 ## Template
 

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,7 @@
           mcp-ynab = pkgs.callPackage ./pkgs/mcp-ynab {
             inherit (nvfetcherSources.mcp-ynab) src version;
           };
+          pulumi-drift-report = pkgs.callPackage ./pkgs/pulumi-drift-report {};
           nautilus-trader = pkgs.callPackage ./pkgs/nautilus-trader {
             inherit (nvfetcherSources.nautilus-trader) src version cargoLock;
             cargo = nautilusRustToolchain;

--- a/overlay.nix
+++ b/overlay.nix
@@ -39,6 +39,7 @@ else let
     mcp-ynab = super.callPackage ./pkgs/mcp-ynab {
       inherit (nvfetcherSources.mcp-ynab) src version;
     };
+    pulumi-drift-report = super.callPackage ./pkgs/pulumi-drift-report {};
     seedtool-cli = super.callPackage ./pkgs/seedtool-cli {};
     spooktacular = super.callPackage ./pkgs/spooktacular {
       inherit (nvfetcherSources.spooktacular) src date;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,10 +8,11 @@
       docfx = super.callPackage ../pkgs/docfx {};
       # epub2tts = super.callPackage ../pkgs/epub2tts {};
       # lean = super.callPackage ../pkgs/lean {};
-      seedtool-cli = super.callPackage ../pkgs/seedtool-cli {};
       mcp-ynab = super.callPackage ../pkgs/mcp-ynab {
         inherit (nvfetcherSources.mcp-ynab) src version;
       };
+      pulumi-drift-report = super.callPackage ../pkgs/pulumi-drift-report {};
+      seedtool-cli = super.callPackage ../pkgs/seedtool-cli {};
       spooktacular = super.callPackage ../pkgs/spooktacular {
         inherit (nvfetcherSources.spooktacular) src date;
       };

--- a/pkgs/pulumi-drift-report/default.nix
+++ b/pkgs/pulumi-drift-report/default.nix
@@ -10,7 +10,12 @@ python3Packages.stdenv.mkDerivation {
 
   nativeBuildInputs = [makeWrapper];
   dontBuild = true;
-  doCheck = false;
+  doCheck = true;
+  nativeCheckInputs = [python3Packages.pytest];
+
+  checkPhase = ''
+    pytest -q tests
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/pulumi-drift-report/default.nix
+++ b/pkgs/pulumi-drift-report/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  makeWrapper,
+  python3Packages,
+}:
+python3Packages.stdenv.mkDerivation {
+  pname = "pulumi-drift-report";
+  version = "0.0.1";
+  src = ../../tools/pulumi-drift-report;
+
+  nativeBuildInputs = [makeWrapper];
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/lib/pulumi-drift-report"
+    cp -r src "$out/lib/pulumi-drift-report/"
+    cp pyproject.toml "$out/lib/pulumi-drift-report/"
+    makeWrapper ${python3Packages.python.interpreter} "$out/bin/pulumi-drift-report" \
+      --set PYTHONPATH "$out/lib/pulumi-drift-report/src" \
+      --add-flags -m \
+      --add-flags jmmaloney4.tools.pulumi_drift_report
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Report Pulumi preview and refresh changes across every stack in a checkout";
+    homepage = "https://github.com/jmmaloney4/jackpkgs";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    mainProgram = "pulumi-drift-report";
+  };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.uv.workspace]
+members = ["tools/pulumi-drift-report"]

--- a/tools/pulumi-drift-report/pyproject.toml
+++ b/tools/pulumi-drift-report/pyproject.toml
@@ -2,7 +2,7 @@
 name = "jmmaloney4-tools-pulumi-drift-report"
 version = "0.0.1"
 description = "Report Pulumi preview and refresh changes across every stack in a checkout"
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.13"
 dependencies = []
 
 [project.scripts]

--- a/tools/pulumi-drift-report/pyproject.toml
+++ b/tools/pulumi-drift-report/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "jmmaloney4-tools-pulumi-drift-report"
+version = "0.0.1"
+description = "Report Pulumi preview and refresh changes across every stack in a checkout"
+requires-python = ">=3.13,<3.14"
+dependencies = []
+
+[project.scripts]
+pulumi-drift-report = "jmmaloney4.tools.pulumi_drift_report.__main__:main"
+
+[build-system]
+requires = ["setuptools==80.9.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.package-data]
+"jmmaloney4.tools.pulumi_drift_report" = ["py.typed"]

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__init__.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__init__.py
@@ -1,0 +1,16 @@
+"""Pulumi drift report tool."""
+
+from .models import DriftReport, ProjectReport, ResourceChange, RunReport, StackReport
+from .report import discover_pulumi_projects, render_text, report_to_json, run_drift_report
+
+__all__ = [
+    "DriftReport",
+    "ProjectReport",
+    "ResourceChange",
+    "RunReport",
+    "StackReport",
+    "discover_pulumi_projects",
+    "render_text",
+    "report_to_json",
+    "run_drift_report",
+]

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__init__.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__init__.py
@@ -1,7 +1,7 @@
 """Pulumi drift report tool."""
 
 from .models import DriftReport, ProjectReport, ResourceChange, RunReport, StackReport
-from .report import discover_pulumi_projects, render_text, report_to_json, run_drift_report
+from .report import discover_pulumi_projects, read_project_name, render_text, report_to_json, run_drift_report
 
 __all__ = [
     "DriftReport",
@@ -10,6 +10,7 @@ __all__ = [
     "RunReport",
     "StackReport",
     "discover_pulumi_projects",
+    "read_project_name",
     "render_text",
     "report_to_json",
     "run_drift_report",

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__main__.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__main__.py
@@ -1,0 +1,74 @@
+"""CLI entry point for the Pulumi drift report tool."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from .report import render_text, report_to_json, run_drift_report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pulumi-drift-report",
+        description="Report Pulumi preview/refresh changes for every stack under a checkout",
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        type=Path,
+        default=Path.cwd(),
+        help="Root directory to scan for Pulumi projects (default: current directory)",
+    )
+    parser.add_argument(
+        "--pulumi-bin",
+        default="pulumi",
+        help="Pulumi CLI executable to invoke (default: pulumi)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("both", "preview", "refresh"),
+        default="both",
+        help="Which Pulumi operation(s) to run per stack",
+    )
+    parser.add_argument(
+        "--stack",
+        action="append",
+        dest="stacks",
+        help="Only inspect the named stack(s); may be passed multiple times",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Render the final report as text or JSON",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    stack_filters = set(args.stacks) if args.stacks else None
+    report = run_drift_report(
+        args.root,
+        pulumi_bin=args.pulumi_bin,
+        mode=args.mode,
+        stack_filters=stack_filters,
+    )
+    if args.format == "json":
+        print(report_to_json(report), end="")
+    else:
+        print(render_text(report))
+
+    has_errors = any(
+        project.errors
+        or any(stack.errors for stack in project.stacks)
+        for project in report.projects
+    ) or bool(report.errors)
+    return 1 if has_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__main__.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/__main__.py
@@ -9,6 +9,13 @@ from typing import Sequence
 from .report import render_text, report_to_json, run_drift_report
 
 
+def _report_has_errors(report) -> bool:
+    return bool(report.errors) or any(
+        project.errors or any(stack.errors for stack in project.stacks)
+        for project in report.projects
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pulumi-drift-report",
@@ -62,11 +69,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         print(render_text(report))
 
-    has_errors = any(
-        project.errors
-        or any(stack.errors for stack in project.stacks)
-        for project in report.projects
-    ) or bool(report.errors)
+    has_errors = _report_has_errors(report)
     return 1 if has_errors else 0
 
 

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/models.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/models.py
@@ -1,0 +1,112 @@
+"""Data models for the Pulumi drift report tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(slots=True)
+class ResourceChange:
+    """A single Pulumi resource step that requires attention."""
+
+    operation: str
+    urn: str
+    resource_type: str | None = None
+    name: str | None = None
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RunReport:
+    """The result of one Pulumi CLI operation for one stack."""
+
+    operation: str
+    command: list[str]
+    exit_code: int
+    summary: dict[str, int] = field(default_factory=dict)
+    resource_changes: list[ResourceChange] = field(default_factory=list)
+    stderr: str = ""
+    error: str | None = None
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.resource_changes)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["has_changes"] = self.has_changes
+        return data
+
+
+@dataclass(slots=True)
+class StackReport:
+    """A stack-level report containing preview and/or refresh results."""
+
+    project_dir: Path
+    project_name: str | None
+    stack_name: str
+    preview: RunReport | None = None
+    refresh: RunReport | None = None
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        return any(
+            report is not None and report.has_changes
+            for report in (self.preview, self.refresh)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_dir": str(self.project_dir),
+            "project_name": self.project_name,
+            "stack_name": self.stack_name,
+            "preview": None if self.preview is None else self.preview.to_dict(),
+            "refresh": None if self.refresh is None else self.refresh.to_dict(),
+            "errors": list(self.errors),
+            "has_changes": self.has_changes,
+        }
+
+
+@dataclass(slots=True)
+class ProjectReport:
+    """A Pulumi project and all inspected stacks."""
+
+    project_dir: Path
+    project_name: str | None
+    stacks: list[StackReport] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_dir": str(self.project_dir),
+            "project_name": self.project_name,
+            "stacks": [stack.to_dict() for stack in self.stacks],
+            "errors": list(self.errors),
+        }
+
+
+@dataclass(slots=True)
+class DriftReport:
+    """The full report for a root checkout."""
+
+    root: Path
+    projects: list[ProjectReport] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        return any(stack.has_changes for project in self.projects for stack in project.stacks)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "root": str(self.root),
+            "projects": [project.to_dict() for project in self.projects],
+            "errors": list(self.errors),
+            "has_changes": self.has_changes,
+        }

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
@@ -131,6 +131,21 @@ def list_stacks(pulumi_bin: str, project_dir: Path) -> list[str]:
     return sorted(names)
 
 
+def _parse_json_lines(stdout: str) -> list[Any]:
+    records: list[Any] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    if not records:
+        raise json.JSONDecodeError("Expected JSONL records", stdout, 0)
+    return records
+
+
 def parse_document(stdout: str) -> Any:
     """Parse Pulumi's JSON output, supporting JSON and JSONL forms."""
     stripped = stdout.strip()
@@ -139,21 +154,12 @@ def parse_document(stdout: str) -> Any:
     try:
         return json.loads(stripped)
     except json.JSONDecodeError:
-        records: list[Any] = []
-        for line in stripped.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-        if records:
-            return records
-        raise
+        return _parse_json_lines(stripped)
 
 
 def _parse_urn(urn: str) -> tuple[str | None, str | None]:
+    if not urn.startswith("urn:pulumi:"):
+        return None, None
     parts = urn.split("::")
     if len(parts) < 4:
         return None, None
@@ -228,7 +234,15 @@ def _run_operation(
     stack_name: str,
     operation: str,
 ) -> RunReport:
-    args: list[str] = [operation, "--json", "--stack", stack_name, "--non-interactive", "--suppress-progress"]
+    args: list[str] = [
+        operation,
+        "--json",
+        "--stack",
+        stack_name,
+        "--non-interactive",
+        "--suppress-progress",
+        "--suppress-outputs",
+    ]
     if operation == "preview":
         args.append("--refresh")
     elif operation == "refresh":

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
@@ -26,7 +26,7 @@ IGNORED_DIR_NAMES = {
 PULUMI_SKIP_UPDATE_CHECK = "1"
 
 
-_PROJECT_NAME_RE = re.compile(r"^name:\s*(?:(?P<dq>\".*?\")|(?P<sq>'.*?')|(?P<bare>\S+))\s*$")
+_PROJECT_NAME_RE = re.compile(r"^name:\s*(?:(?P<dq>\".*?\")|(?P<sq>'.*?')|(?P<bare>[^#\s]+))\s*(?:#.*)?$")
 
 
 def discover_pulumi_projects(root: Path) -> list[Path]:
@@ -145,7 +145,7 @@ def _parse_urn(urn: str) -> tuple[str | None, str | None]:
 
 def _step_to_change(step: dict[str, Any]) -> ResourceChange | None:
     op = str(step.get("op") or step.get("operation") or step.get("kind") or "unknown")
-    if op.lower() in {"same", "unchanged", "no-op"}:
+    if op.lower() in {"same", "unchanged", "no-op", "read"}:
         return None
 
     urn = step.get("urn")
@@ -186,16 +186,17 @@ def _steps_from_document(document: Any) -> list[dict[str, Any]]:
         return []
 
     if isinstance(document, list):
-        if all(isinstance(item, dict) for item in document) and any(
-            any(key in item for key in ("op", "urn", "operation", "kind"))
-            for item in document
-        ):
-            return [item for item in document if isinstance(item, dict)]
+        steps: list[dict[str, Any]] = []
         for item in document:
-            if isinstance(item, dict):
-                steps = item.get("steps")
-                if isinstance(steps, list):
-                    return [step for step in steps if isinstance(step, dict)]
+            if not isinstance(item, dict):
+                continue
+            nested_steps: Any = item.get("steps")
+            if isinstance(nested_steps, list):
+                steps.extend(step for step in nested_steps if isinstance(step, dict))
+                continue
+            if any(key in item for key in ("op", "urn", "operation", "kind")):
+                steps.append(item)
+        return steps
     return []
 
 
@@ -229,9 +230,19 @@ def _run_operation(
             error=error,
         )
 
-    document = parse_document(result.stdout)
+    try:
+        document = parse_document(result.stdout)
+    except (json.JSONDecodeError, RuntimeError) as exc:
+        return RunReport(
+            operation=operation,
+            command=_pulumi_command(pulumi_bin, project_dir, *args),
+            exit_code=result.returncode,
+            stderr=result.stderr,
+            error=f"Failed to parse Pulumi output: {exc}",
+        )
+
     steps = _steps_from_document(document)
-    changes = []
+    changes: list[ResourceChange] = []
     for step in steps:
         change = _step_to_change(step)
         if change is not None:

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
@@ -25,36 +25,39 @@ IGNORED_DIR_NAMES = {
 
 PULUMI_SKIP_UPDATE_CHECK = "1"
 
+_PULUMI_CONFIG_FILENAMES = ("Pulumi.yaml", "Pulumi.yml")
+
 
 _PROJECT_NAME_RE = re.compile(r"^name:\s*(?:(?P<dq>\".*?\")|(?P<sq>'.*?')|(?P<bare>[^#\s]+))\s*(?:#.*)?$")
 
 
 def discover_pulumi_projects(root: Path) -> list[Path]:
-    """Find directories containing a Pulumi.yaml file under *root*."""
+    """Find directories containing a Pulumi project file under *root*."""
     projects: list[Path] = []
     root = root.resolve()
     for current_root, dirnames, filenames in os.walk(root):
         dirnames[:] = sorted(d for d in dirnames if d not in IGNORED_DIR_NAMES)
-        if "Pulumi.yaml" in filenames:
+        if any(filename in filenames for filename in _PULUMI_CONFIG_FILENAMES):
             projects.append(Path(current_root))
     return sorted(projects)
 
 
 def read_project_name(project_dir: Path) -> str | None:
-    """Extract the project name from Pulumi.yaml if possible."""
-    config = project_dir / "Pulumi.yaml"
-    try:
-        text = config.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return None
-    for line in text.splitlines():
-        match = _PROJECT_NAME_RE.match(line.strip())
-        if not match:
+    """Extract the project name from a Pulumi project file if possible."""
+    for filename in _PULUMI_CONFIG_FILENAMES:
+        config = project_dir / filename
+        try:
+            text = config.read_text(encoding="utf-8")
+        except FileNotFoundError:
             continue
-        value = match.group("dq") or match.group("sq") or match.group("bare")
-        if value is None:
-            return None
-        return value.strip().strip("\"'")
+        for line in text.splitlines():
+            match = _PROJECT_NAME_RE.match(line.strip())
+            if not match:
+                continue
+            value = match.group("dq") or match.group("sq") or match.group("bare")
+            if value is None:
+                return None
+            return value.strip().strip("\"'")
     return None
 
 

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
@@ -1,0 +1,332 @@
+"""Pulumi drift report orchestration and rendering."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from .models import DriftReport, ProjectReport, ResourceChange, RunReport, StackReport
+
+IGNORED_DIR_NAMES = {
+    ".direnv",
+    ".git",
+    ".venv",
+    "build",
+    "dist",
+    "node_modules",
+    "result",
+    "__pycache__",
+}
+
+PULUMI_SKIP_UPDATE_CHECK = "1"
+
+
+_PROJECT_NAME_RE = re.compile(r"^name:\s*(?:(?P<dq>\".*?\")|(?P<sq>'.*?')|(?P<bare>\S+))\s*$")
+
+
+def discover_pulumi_projects(root: Path) -> list[Path]:
+    """Find directories containing a Pulumi.yaml file under *root*."""
+    projects: list[Path] = []
+    root = root.resolve()
+    for current_root, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in IGNORED_DIR_NAMES)
+        if "Pulumi.yaml" in filenames:
+            projects.append(Path(current_root))
+    return sorted(projects)
+
+
+def read_project_name(project_dir: Path) -> str | None:
+    """Extract the project name from Pulumi.yaml if possible."""
+    config = project_dir / "Pulumi.yaml"
+    try:
+        text = config.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    for line in text.splitlines():
+        match = _PROJECT_NAME_RE.match(line.strip())
+        if not match:
+            continue
+        value = match.group("dq") or match.group("sq") or match.group("bare")
+        if value is None:
+            return None
+        return value.strip().strip("\"'")
+    return None
+
+
+def _base_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.setdefault("PULUMI_SKIP_UPDATE_CHECK", PULUMI_SKIP_UPDATE_CHECK)
+    return env
+
+
+def _pulumi_command(
+    pulumi_bin: str,
+    project_dir: Path,
+    *args: str,
+) -> list[str]:
+    return [pulumi_bin, "-C", str(project_dir), *args]
+
+
+def run_pulumi_json(
+    pulumi_bin: str,
+    project_dir: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run a Pulumi CLI command and capture stdout/stderr."""
+    return subprocess.run(
+        _pulumi_command(pulumi_bin, project_dir, *args),
+        capture_output=True,
+        check=False,
+        env=_base_env(),
+        text=True,
+    )
+
+
+def list_stacks(pulumi_bin: str, project_dir: Path) -> list[str]:
+    """Return all stack names for the current Pulumi project."""
+    result = run_pulumi_json(
+        pulumi_bin,
+        project_dir,
+        "stack",
+        "ls",
+        "--json",
+        "--non-interactive",
+    )
+    if result.returncode != 0:
+        raise RuntimeError((result.stderr or result.stdout or "pulumi stack ls failed").strip())
+
+    document = parse_document(result.stdout)
+    if not isinstance(document, list):
+        raise RuntimeError("pulumi stack ls returned unexpected JSON")
+
+    names: list[str] = []
+    for item in document:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return sorted(names)
+
+
+def parse_document(stdout: str) -> Any:
+    """Parse Pulumi's JSON output, supporting JSON and JSONL forms."""
+    stripped = stdout.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        records: list[Any] = []
+        for line in stripped.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        if records:
+            return records
+        raise
+
+
+def _parse_urn(urn: str) -> tuple[str | None, str | None]:
+    parts = urn.split("::")
+    if len(parts) < 4:
+        return None, None
+    return parts[-2] or None, parts[-1] or None
+
+
+def _step_to_change(step: dict[str, Any]) -> ResourceChange | None:
+    op = str(step.get("op") or step.get("operation") or step.get("kind") or "unknown")
+    if op.lower() in {"same", "unchanged", "no-op"}:
+        return None
+
+    urn = step.get("urn")
+    if not isinstance(urn, str) or not urn:
+        for state_key in ("newState", "oldState"):
+            state = step.get(state_key)
+            if isinstance(state, dict):
+                candidate = state.get("urn")
+                if isinstance(candidate, str) and candidate:
+                    urn = candidate
+                    break
+    if not isinstance(urn, str) or not urn:
+        return None
+
+    resource_type, name = _parse_urn(urn)
+    detail: dict[str, Any] = {}
+    for key in ("reason", "detailedDiff"):
+        value = step.get(key)
+        if value is not None:
+            detail[key] = value
+
+    return ResourceChange(
+        operation=op,
+        urn=urn,
+        resource_type=resource_type,
+        name=name,
+        detail=detail,
+    )
+
+
+def _steps_from_document(document: Any) -> list[dict[str, Any]]:
+    if isinstance(document, dict):
+        steps = document.get("steps")
+        if isinstance(steps, list):
+            return [step for step in steps if isinstance(step, dict)]
+        if any(key in document for key in ("op", "urn", "operation", "kind")):
+            return [document]
+        return []
+
+    if isinstance(document, list):
+        if all(isinstance(item, dict) for item in document) and any(
+            any(key in item for key in ("op", "urn", "operation", "kind"))
+            for item in document
+        ):
+            return [item for item in document if isinstance(item, dict)]
+        for item in document:
+            if isinstance(item, dict):
+                steps = item.get("steps")
+                if isinstance(steps, list):
+                    return [step for step in steps if isinstance(step, dict)]
+    return []
+
+
+def _summary_from_changes(changes: list[ResourceChange]) -> dict[str, int]:
+    counts = Counter(change.operation for change in changes)
+    return dict(sorted(counts.items()))
+
+
+def _run_operation(
+    pulumi_bin: str,
+    project_dir: Path,
+    stack_name: str,
+    operation: str,
+) -> RunReport:
+    args: list[str] = [operation, "--json", "--stack", stack_name, "--non-interactive", "--suppress-progress"]
+    if operation == "preview":
+        args.append("--refresh")
+    elif operation == "refresh":
+        args.append("--preview-only")
+    else:
+        raise ValueError(f"unsupported operation: {operation}")
+
+    result = run_pulumi_json(pulumi_bin, project_dir, *args)
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout or f"pulumi {operation} failed").strip()
+        return RunReport(
+            operation=operation,
+            command=_pulumi_command(pulumi_bin, project_dir, *args),
+            exit_code=result.returncode,
+            stderr=result.stderr,
+            error=error,
+        )
+
+    document = parse_document(result.stdout)
+    steps = _steps_from_document(document)
+    changes = []
+    for step in steps:
+        change = _step_to_change(step)
+        if change is not None:
+            changes.append(change)
+    changes.sort(key=lambda change: (change.urn, change.operation))
+
+    return RunReport(
+        operation=operation,
+        command=_pulumi_command(pulumi_bin, project_dir, *args),
+        exit_code=result.returncode,
+        summary=_summary_from_changes(changes),
+        resource_changes=changes,
+        stderr=result.stderr,
+    )
+
+
+def run_drift_report(
+    root: Path,
+    pulumi_bin: str = "pulumi",
+    mode: str = "both",
+    stack_filters: set[str] | None = None,
+) -> DriftReport:
+    """Generate a full report for every Pulumi project under *root*."""
+    projects: list[ProjectReport] = []
+    project_paths = discover_pulumi_projects(root)
+    for project_dir in project_paths:
+        project_name = read_project_name(project_dir)
+        project_report = ProjectReport(project_dir=project_dir, project_name=project_name)
+        try:
+            stacks = list_stacks(pulumi_bin, project_dir)
+        except RuntimeError as exc:
+            project_report.errors.append(str(exc))
+            projects.append(project_report)
+            continue
+
+        if stack_filters is not None:
+            stacks = [stack for stack in stacks if stack in stack_filters]
+
+        for stack_name in stacks:
+            stack_report = StackReport(
+                project_dir=project_dir,
+                project_name=project_name,
+                stack_name=stack_name,
+            )
+            if mode in {"preview", "both"}:
+                stack_report.preview = _run_operation(pulumi_bin, project_dir, stack_name, "preview")
+                if stack_report.preview.error is not None:
+                    stack_report.errors.append(stack_report.preview.error)
+            if mode in {"refresh", "both"}:
+                stack_report.refresh = _run_operation(pulumi_bin, project_dir, stack_name, "refresh")
+                if stack_report.refresh.error is not None:
+                    stack_report.errors.append(stack_report.refresh.error)
+            project_report.stacks.append(stack_report)
+        projects.append(project_report)
+    return DriftReport(root=root, projects=projects)
+
+
+def render_text(report: DriftReport) -> str:
+    """Render a human-friendly report."""
+    lines: list[str] = []
+    lines.append(f"Pulumi drift report for {report.root}")
+    if not report.projects:
+        lines.append("No Pulumi projects found.")
+        return "\n".join(lines)
+
+    for project in report.projects:
+        header = str(project.project_dir)
+        if project.project_name:
+            header += f" ({project.project_name})"
+        lines.append(header)
+        for error in project.errors:
+            lines.append(f"  ERROR: {error}")
+        for stack in project.stacks:
+            lines.append(f"  Stack {stack.stack_name}")
+            for error in stack.errors:
+                lines.append(f"    ERROR: {error}")
+            for label, run in (("preview", stack.preview), ("refresh", stack.refresh)):
+                if run is None:
+                    continue
+                if run.error is not None:
+                    lines.append(f"    {label}: failed ({run.error})")
+                    continue
+                if not run.resource_changes:
+                    lines.append(f"    {label}: no changes")
+                    continue
+                summary = ", ".join(f"{count} {op}" for op, count in sorted(run.summary.items()))
+                lines.append(f"    {label}: {summary}")
+                for change in run.resource_changes:
+                    suffix = f" [{change.resource_type}]" if change.resource_type else ""
+                    lines.append(f"      {change.operation}: {change.urn}{suffix}")
+    if report.errors:
+        lines.append("Global errors:")
+        lines.extend(f"  - {error}" for error in report.errors)
+    return "\n".join(lines)
+
+
+def report_to_json(report: DriftReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n"

--- a/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
+++ b/tools/pulumi-drift-report/src/jmmaloney4/tools/pulumi_drift_report/report.py
@@ -12,6 +12,11 @@ from typing import Any
 
 from .models import DriftReport, ProjectReport, ResourceChange, RunReport, StackReport
 
+try:  # optional at runtime; Nix packaging provides it, regex remains a fallback
+    import yaml
+except ImportError:  # pragma: no cover - fallback for minimal environments
+    yaml = None
+
 IGNORED_DIR_NAMES = {
     ".direnv",
     ".git",
@@ -50,6 +55,15 @@ def read_project_name(project_dir: Path) -> str | None:
             text = config.read_text(encoding="utf-8")
         except FileNotFoundError:
             continue
+        if yaml is not None:
+            try:
+                document = yaml.safe_load(text)
+            except Exception:  # pragma: no cover - fallback for malformed config
+                document = None
+            if isinstance(document, dict):
+                name = document.get("name")
+                if isinstance(name, str) and name.strip():
+                    return name.strip().strip('"')
         for line in text.splitlines():
             match = _PROJECT_NAME_RE.match(line.strip())
             if not match:

--- a/tools/pulumi-drift-report/tests/test_drift_report.py
+++ b/tools/pulumi-drift-report/tests/test_drift_report.py
@@ -61,6 +61,8 @@ elif 'preview' in args:
         print(json.dumps({'steps': [{'op': 'create', 'urn': 'urn:pulumi:dev::demo-project::pkg:index:Thing::second'}]}))
     elif mode == 'invalid':
         print('not-json')
+    elif mode == 'malformed-urn':
+        print(json.dumps({'steps': [{'op': 'update', 'urn': 'not-a-pulumi-urn'}]}))
     else:
         print(
             json.dumps(
@@ -156,6 +158,23 @@ def test_run_drift_report_reports_parse_errors_per_stack(
     assert preview.error is not None
     assert "Failed to parse Pulumi output" in preview.error
     assert report.projects[0].stacks[0].errors
+
+
+def test_run_drift_report_handles_malformed_urns(
+    pulumi_checkout: Path,
+    fake_pulumi_bin: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", f"{fake_pulumi_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("PULUMI_FAKE_MODE", "malformed-urn")
+
+    report = run_drift_report(pulumi_checkout, pulumi_bin="pulumi")
+    preview = report.projects[0].stacks[0].preview
+
+    assert preview is not None
+    assert preview.resource_changes[0].urn == "not-a-pulumi-urn"
+    assert preview.resource_changes[0].resource_type is None
+    assert preview.resource_changes[0].name is None
 
 
 def test_cli_json_output(

--- a/tools/pulumi-drift-report/tests/test_drift_report.py
+++ b/tools/pulumi-drift-report/tests/test_drift_report.py
@@ -15,6 +15,7 @@ if str(SRC) not in sys.path:
 
 from jmmaloney4.tools.pulumi_drift_report import (  # noqa: E402, I001
     discover_pulumi_projects,
+    read_project_name,
     render_text,
     run_drift_report,
 )  # type: ignore[import-not-found]
@@ -88,6 +89,17 @@ else:
 def test_discover_projects_ignores_node_modules(pulumi_checkout: Path) -> None:
     projects = discover_pulumi_projects(pulumi_checkout)
     assert projects == [pulumi_checkout]
+
+
+def test_discover_projects_supports_pulumi_yml(tmp_path: Path) -> None:
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "Pulumi.yml").write_text("name: demo-yml\nruntime: nodejs\n", encoding="utf-8")
+
+    projects = discover_pulumi_projects(root)
+
+    assert projects == [root]
+    assert read_project_name(root) == "demo-yml"
 
 
 def test_run_drift_report_renders_preview_and_refresh(

--- a/tools/pulumi-drift-report/tests/test_drift_report.py
+++ b/tools/pulumi-drift-report/tests/test_drift_report.py
@@ -47,29 +47,37 @@ def fake_pulumi_bin(tmp_path: Path) -> Path:
 from __future__ import annotations
 
 import json
+import os
 import sys
 
 args = sys.argv[1:]
-if "stack" in args and "ls" in args:
-    print(json.dumps([{"name": "dev"}]))
-elif "preview" in args:
-    print(
-        json.dumps(
-            {
-                "steps": [
-                    {
-                        "op": "update",
-                        "urn": "urn:pulumi:dev::demo-project::pkg:index:Thing::example",
-                        "type": "pkg:index:Thing",
-                    }
-                ]
-            }
+mode = os.environ.get('PULUMI_FAKE_MODE', 'normal')
+if 'stack' in args and 'ls' in args:
+    print(json.dumps([{'name': 'dev'}]))
+elif 'preview' in args:
+    if mode == 'jsonl':
+        print(json.dumps({'steps': [{'op': 'update', 'urn': 'urn:pulumi:dev::demo-project::pkg:index:Thing::first'}]}))
+        print(json.dumps({'steps': [{'op': 'create', 'urn': 'urn:pulumi:dev::demo-project::pkg:index:Thing::second'}]}))
+    elif mode == 'invalid':
+        print('not-json')
+    else:
+        print(
+            json.dumps(
+                {
+                    'steps': [
+                        {
+                            'op': 'update',
+                            'urn': 'urn:pulumi:dev::demo-project::pkg:index:Thing::example',
+                            'type': 'pkg:index:Thing',
+                        }
+                    ]
+                }
+            )
         )
-    )
-elif "refresh" in args:
-    print(json.dumps({"steps": []}))
+elif 'refresh' in args:
+    print(json.dumps({'steps': []}))
 else:
-    print(json.dumps({"steps": []}))
+    print(json.dumps({'steps': []}))
 """,
         encoding="utf-8",
     )
@@ -100,6 +108,42 @@ def test_run_drift_report_renders_preview_and_refresh(
     assert not report.errors
     assert report.projects[0].stacks[0].preview is not None
     assert report.projects[0].stacks[0].preview.resource_changes[0].operation == "update"
+
+
+def test_run_drift_report_handles_jsonl_and_all_steps(
+    pulumi_checkout: Path,
+    fake_pulumi_bin: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", f"{fake_pulumi_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("PULUMI_FAKE_MODE", "jsonl")
+
+    report = run_drift_report(pulumi_checkout, pulumi_bin="pulumi")
+    preview = report.projects[0].stacks[0].preview
+
+    assert preview is not None
+    changes = preview.resource_changes
+
+    assert [change.operation for change in changes] == ["update", "create"]
+    assert any(change.urn.endswith("::first") for change in changes)
+    assert any(change.urn.endswith("::second") for change in changes)
+
+
+def test_run_drift_report_reports_parse_errors_per_stack(
+    pulumi_checkout: Path,
+    fake_pulumi_bin: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", f"{fake_pulumi_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("PULUMI_FAKE_MODE", "invalid")
+
+    report = run_drift_report(pulumi_checkout, pulumi_bin="pulumi")
+    preview = report.projects[0].stacks[0].preview
+
+    assert preview is not None
+    assert preview.error is not None
+    assert "Failed to parse Pulumi output" in preview.error
+    assert report.projects[0].stacks[0].errors
 
 
 def test_cli_json_output(

--- a/tools/pulumi-drift-report/tests/test_drift_report.py
+++ b/tools/pulumi-drift-report/tests/test_drift_report.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from jmmaloney4.tools.pulumi_drift_report import (  # noqa: E402, I001
+    discover_pulumi_projects,
+    render_text,
+    run_drift_report,
+)  # type: ignore[import-not-found]
+
+
+@pytest.fixture()
+def pulumi_checkout(tmp_path: Path) -> Path:
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "Pulumi.yaml").write_text(
+        "name: demo-project\nruntime: nodejs\n",
+        encoding="utf-8",
+    )
+    ignored = root / "node_modules" / "nested"
+    ignored.mkdir(parents=True)
+    (ignored / "Pulumi.yaml").write_text(
+        "name: ignored\nruntime: nodejs\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture()
+def fake_pulumi_bin(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script = bin_dir / "pulumi"
+    script.write_text(
+        """#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+
+args = sys.argv[1:]
+if "stack" in args and "ls" in args:
+    print(json.dumps([{"name": "dev"}]))
+elif "preview" in args:
+    print(
+        json.dumps(
+            {
+                "steps": [
+                    {
+                        "op": "update",
+                        "urn": "urn:pulumi:dev::demo-project::pkg:index:Thing::example",
+                        "type": "pkg:index:Thing",
+                    }
+                ]
+            }
+        )
+    )
+elif "refresh" in args:
+    print(json.dumps({"steps": []}))
+else:
+    print(json.dumps({"steps": []}))
+""",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return bin_dir
+
+
+def test_discover_projects_ignores_node_modules(pulumi_checkout: Path) -> None:
+    projects = discover_pulumi_projects(pulumi_checkout)
+    assert projects == [pulumi_checkout]
+
+
+def test_run_drift_report_renders_preview_and_refresh(
+    pulumi_checkout: Path,
+    fake_pulumi_bin: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", f"{fake_pulumi_bin}:{os.environ['PATH']}")
+    report = run_drift_report(pulumi_checkout, pulumi_bin="pulumi")
+    text = render_text(report)
+
+    assert "Pulumi drift report for" in text
+    assert "demo-project" in text
+    assert "Stack dev" in text
+    assert "preview: 1 update" in text
+    assert "refresh: no changes" in text
+    assert "urn:pulumi:dev::demo-project::pkg:index:Thing::example" in text
+    assert not report.errors
+    assert report.projects[0].stacks[0].preview is not None
+    assert report.projects[0].stacks[0].preview.resource_changes[0].operation == "update"
+
+
+def test_cli_json_output(
+    pulumi_checkout: Path,
+    fake_pulumi_bin: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PATH", f"{fake_pulumi_bin}:{os.environ['PATH']}")
+    from jmmaloney4.tools.pulumi_drift_report.__main__ import main
+
+    exit_code = main([str(pulumi_checkout), "--pulumi-bin", "pulumi", "--format", "json"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    data = json.loads(captured.out)
+    assert data["root"] == str(pulumi_checkout)
+    assert data["projects"][0]["stacks"][0]["preview"]["resource_changes"][0]["operation"] == "update"


### PR DESCRIPTION
## Summary
- Add `pulumi-drift-report`, a Python CLI for scanning Pulumi projects under a checkout.
- Discover stacks with `pulumi stack ls --json`, run `preview`/`refresh`, and summarize the resources that would change.
- Package the tool in jackpkgs with the usual Nix overlays and workspace layout.

## Test Plan
- `nix build .#pulumi-drift-report`
- `nix run .#pulumi-drift-report -- <fake checkout>` with a stub Pulumi CLI
- `python -m pytest` for the tool tests in the worktree

## Risks
- Parsing Pulumi JSON is CLI-version-sensitive, so the JSON reader is intentionally tolerant.
- The first version depends on the Pulumi CLI being installed and authenticated in the target environment.
- The tool reports drift; it does not modify state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-only but shells out to Pulumi for every stack; JSON parsing and auth/backend setup are environment- and CLI-version-dependent, so CI/local runs can fail or mis-parse without clear infra guarantees.
> 
> **Overview**
> Adds **`pulumi-drift-report`**, a new Python CLI that walks a checkout for Pulumi projects, lists stacks via the Pulumi CLI, runs **preview** (with refresh) and/or **refresh** (preview-only) per stack, and aggregates non-`same` resource steps into **text or JSON** reports. Discovery skips common junk dirs (`node_modules`, `.git`, etc.); parsing tolerates single JSON blobs and JSONL-style output.
> 
> The tool is wired into jackpkgs as a first-class package (`pkgs/pulumi-drift-report` with pytest in `checkPhase`), exposed on the flake, default overlay, and root `overlay.nix`, and registered in the root **uv workspace**. **ADR-041** documents scope (report-only, subprocess-based, no Automation API). **README** lists the new package.
> 
> **Risk:** behavior depends on installed/authenticated **Pulumi CLI** and version-specific JSON shapes; failures surface as per-stack errors and a non-zero exit when the report contains errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76092b48af3469fd5fb50a6d8e564932234485a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->