### PR TITLE
fix(just): expand $new_version in cut recipe commit message

### DIFF
--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -384,7 +384,11 @@ in {
             hasFiles = cutCfg.files != [];
             npmFiles = lib.filter (f: f.type == "npm") cutCfg.files;
             allFilePaths = map (f: f.path) cutCfg.files;
-            commitMsg = lib.replaceStrings ["{version}"] ["\${new_version}"] cutCfg.commitMessage;
+            # Build commit message with bash variable interpolation.
+            # We use the prefix before {version} as a static part and inject
+            # "$new_version" as a bash-expandable reference inside double quotes.
+            commitMsgPrefix = lib.head (lib.splitString "{version}" cutCfg.commitMessage);
+            commitMsgSuffix = lib.concatStrings (lib.tail (lib.splitString "{version}" cutCfg.commitMessage));
 
             # Generate npm version bump commands at Nix eval time
             npmBumpCommands =
@@ -432,7 +436,7 @@ in {
               ++ [
                 ""
                 "git add ${lib.escapeShellArgs allFilePaths}"
-                "git commit -m ${lib.escapeShellArg commitMsg}"
+                "git commit -m \"${commitMsgPrefix}\$new_version${commitMsgSuffix}\""
                 ""
                 "git tag -a \"\$new_tag\" -m \"Release \$new_tag\""
                 "git push --atomic origin ${lib.escapeShellArg cutCfg.branch} \"\$new_tag\""

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -396,7 +396,7 @@ in {
               parts = lib.splitString "{version}" cutCfg.commitMessage;
               escapedParts = map lib.escapeShellArg parts;
             in
-              lib.concatStringsSep "\"\$new_version\"" escapedParts;
+              lib.concatStringsSep "\"$new_version\"" escapedParts;
 
             # Generate npm version bump commands at Nix eval time
             npmBumpCommands =

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -384,16 +384,11 @@ in {
             hasFiles = cutCfg.files != [];
             npmFiles = lib.filter (f: f.type == "npm") cutCfg.files;
             allFilePaths = map (f: f.path) cutCfg.files;
-            # Build commit message with bash variable interpolation.
-            # Split at {version}, escape each static part with escapeShellArg
-            # (producing single-quoted, injection-safe strings), then join
-            # with the bash-expandable variable "$new_version". When {version}
-            # is absent, the list has one element and no joiner is inserted.
-            commitMsg = let
-              parts = lib.splitString "{version}" cutCfg.commitMessage;
-              escapedParts = map lib.escapeShellArg parts;
-            in
-              lib.concatStringsSep "\"\$new_version\"" escapedParts;
+            # Escape the full commit message for shell safety (single-quoted),
+            # then replace {version} with the bash-expandable variable "$new_version".
+            # When {version} is absent, the template passes through unchanged.
+            commitMsg = lib.replaceStrings ["{version}"] ["\"$new_version\""]
+              (lib.escapeShellArg cutCfg.commitMessage);
 
             # Generate npm version bump commands at Nix eval time
             npmBumpCommands =

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -385,10 +385,15 @@ in {
             npmFiles = lib.filter (f: f.type == "npm") cutCfg.files;
             allFilePaths = map (f: f.path) cutCfg.files;
             # Build commit message with bash variable interpolation.
-            # We use the prefix before {version} as a static part and inject
-            # "$new_version" as a bash-expandable reference inside double quotes.
-            commitMsgPrefix = lib.head (lib.splitString "{version}" cutCfg.commitMessage);
-            commitMsgSuffix = lib.concatStrings (lib.tail (lib.splitString "{version}" cutCfg.commitMessage));
+            # Split at {version}, escape each static part with escapeShellArg
+            # (producing single-quoted, injection-safe strings), then join
+            # with the bash-expandable variable "$new_version". When {version}
+            # is absent, the list has one element and no joiner is inserted.
+            commitMsg = let
+              parts = lib.splitString "{version}" cutCfg.commitMessage;
+              escapedParts = map lib.escapeShellArg parts;
+            in
+              lib.concatStringsSep "\"\$new_version\"" escapedParts;
 
             # Generate npm version bump commands at Nix eval time
             npmBumpCommands =
@@ -436,7 +441,7 @@ in {
               ++ [
                 ""
                 "git add ${lib.escapeShellArgs allFilePaths}"
-                "git commit -m \"${commitMsgPrefix}\$new_version${commitMsgSuffix}\""
+                "git commit -m ${commitMsg}"
                 ""
                 "git tag -a \"\$new_tag\" -m \"Release \$new_tag\""
                 "git push --atomic origin ${lib.escapeShellArg cutCfg.branch} \"\$new_tag\""

--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -384,11 +384,19 @@ in {
             hasFiles = cutCfg.files != [];
             npmFiles = lib.filter (f: f.type == "npm") cutCfg.files;
             allFilePaths = map (f: f.path) cutCfg.files;
-            # Escape the full commit message for shell safety (single-quoted),
-            # then replace {version} with the bash-expandable variable "$new_version".
-            # When {version} is absent, the template passes through unchanged.
-            commitMsg = lib.replaceStrings ["{version}"] ["\"$new_version\""]
-              (lib.escapeShellArg cutCfg.commitMessage);
+            # Build the git commit -m argument by splitting at {version},
+            # escaping each static part with escapeShellArg (single-quoted,
+            # injection-safe), and joining with the bash-expandable variable
+            # "$new_version" in its own double-quoted segment. Bash concatenates
+            # adjacent quoted segments, so 'text'"$var"'more' expands $var
+            # while keeping the static parts literal.
+            # When {version} is absent, the list has one element and no
+            # joiner is inserted — the template passes through unchanged.
+            commitMsg = let
+              parts = lib.splitString "{version}" cutCfg.commitMessage;
+              escapedParts = map lib.escapeShellArg parts;
+            in
+              lib.concatStringsSep "\"\$new_version\"" escapedParts;
 
             # Generate npm version bump commands at Nix eval time
             npmBumpCommands =


### PR DESCRIPTION
## Problem

The `jackpkgs.just.cut` module generates a `git commit -m` line that wraps the commit message in **single quotes** (via `lib.escapeShellArg`), preventing bash from expanding `$new_version`. The resulting commit message is the literal string:

```
release: bump sector7 to ${new_version}
```

instead of the actual version:

```
release: bump sector7 to v0.10.3
```

## Fix

Replace the `escapeShellArg` approach with direct double-quoted string interpolation. Split the `commitMessage` template at `{version}` and inject `$new_version` as a bash-expandable variable between the prefix and suffix parts.

**Before** (generated bash):
```bash
git commit -m 'release: bump sector7 to ${new_version}'
```

**After** (generated bash):
```bash
git commit -m "release: bump sector7 to $new_version"
```

## Testing

- `module-testCutWithNpm` — ✅ passes (justfile syntax validated)
- `module-testCutTagOnly` — ✅ passes (unaffected, no commit line)
- `justfile-testRealWorldGeneration` — ✅ passes

Note: existing nix-unit tests validate justfile **syntax** only (via `just --dump`), not module output. This is a known limitation documented in `tests/module-justfiles.nix`. The test helper `testCutWithNpm` manually constructs the expected justfile content using the same `mkRecipe` helpers rather than evaluating the module system with mock config.

## Affected repos

Any repo using `jackpkgs.just.cut.enable = true` with custom `commitMessage` containing `{version}` — sector7 is the primary consumer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to generated justfile commit-line quoting for `jackpkgs.just.cut`; static message parts stay shell-escaped.
> 
> **Overview**
> Fixes **`jackpkgs.just.cut`** so release commits get the real bumped version in the message instead of a literal `${new_version}` placeholder.
> 
> The generated `git commit -m` line no longer wraps the whole template in a single `escapeShellArg` (single-quoted) string. At Nix eval time it **splits** `commitMessage` on `{version}`, **single-quotes** each static segment for safety, and **joins** them with a bash `"$new_version"` segment so the cut recipe expands the version at runtime. Templates without `{version}` behave as before.
> 
> Only the **with-files** cut path changes; tag-only cut is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afadf4aeb8af6724429846b0510dda523596ea36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->