### PR TITLE
chore(codex-proxy): bump fork to aa8d9032 for buffered usage reporting

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,138 +1,138 @@
 {
-	"codex-proxy": {
-		"cargoLock": null,
-		"date": "2026-05-29",
-		"extract": null,
-		"name": "codex-proxy",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "jmmaloney4",
-			"repo": "codex-proxy",
-			"rev": "0f453a3038fdef274d55dc8e9aaee0547495ff23",
-			"sha256": "sha256-PfMZI7PmmpuvGRtEmy97wojsVO/snzuPtlZSLcJ7KYE=",
-			"sparseCheckout": [],
-			"type": "github"
-		},
-		"version": "0f453a3038fdef274d55dc8e9aaee0547495ff23"
-	},
-	"gemini-proxy": {
-		"cargoLock": null,
-		"date": "2026-03-09",
-		"extract": null,
-		"name": "gemini-proxy",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "KashifKhn",
-			"repo": "gemini-proxy",
-			"rev": "5f701a244ed3c4699e6c1b0550bd50e961601ebe",
-			"sha256": "sha256-RYDeVd66AXHHbm7TzX8et8QUspvfjxpkq8o4VXh76Cw=",
-			"sparseCheckout": [],
-			"type": "github"
-		},
-		"version": "5f701a244ed3c4699e6c1b0550bd50e961601ebe"
-	},
-	"mcp-ynab": {
-		"cargoLock": null,
-		"date": "2026-03-07",
-		"extract": null,
-		"name": "mcp-ynab",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "jmmaloney4",
-			"repo": "mcp-ynab",
-			"rev": "b7b21e4990fa824b24bb86f2f2d8fd053817f047",
-			"sha256": "sha256-Ukh5FvBmk5A4ol2IRpBvrWp1K6fcWDfxssiw0gJ9l84=",
-			"sparseCheckout": [],
-			"type": "github"
-		},
-		"version": "b7b21e4990fa824b24bb86f2f2d8fd053817f047"
-	},
-	"nautilus-trader": {
-		"cargoLock": {
-			"Cargo.lock": [
-				"sha256-5NgHvKZoydlqxfMvXEjZy73g8kJGoIV2L7kRKnfkRXc=/Cargo.lock",
-				{}
-			]
-		},
-		"date": "2026-05-29",
-		"extract": null,
-		"name": "nautilus-trader",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "nautechsystems",
-			"repo": "nautilus_trader",
-			"rev": "1408bec68bb01ba1c3166e1f3803f1536fc9c950",
-			"sha256": "sha256-5NgHvKZoydlqxfMvXEjZy73g8kJGoIV2L7kRKnfkRXc=",
-			"sparseCheckout": [],
-			"type": "github"
-		},
-		"version": "1408bec68bb01ba1c3166e1f3803f1536fc9c950"
-	},
-	"spooktacular": {
-		"cargoLock": null,
-		"date": "2026-04-19",
-		"extract": null,
-		"name": "spooktacular",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "Spooky-Labs",
-			"repo": "spooktacular",
-			"rev": "f36634b84e1d38d81bd282b0f88a497557e4a520",
-			"sha256": "sha256-x8bqwvbw0WZKASEIDqCVR8b91RqJKSLYcNSfe68WzrE=",
-			"sparseCheckout": [],
-			"type": "github"
-		},
-		"version": "f36634b84e1d38d81bd282b0f88a497557e4a520"
-	},
-	"tod": {
-		"cargoLock": {
-			"Cargo.lock": [
-				"sha256-091_1go_dBpTxK60Zh1cuzEJl7Fh7X7vpStRRoKFOzA=/Cargo.lock",
-				{}
-			]
-		},
-		"date": null,
-		"extract": null,
-		"name": "tod",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "alanvardy",
-			"repo": "tod",
-			"rev": "v0.12.1",
-			"sha256": "sha256-091/1go/dBpTxK60Zh1cuzEJl7Fh7X7vpStRRoKFOzA=",
-			"sparseCheckout": [],
-			"type": "github"
-		},
-		"version": "v0.12.1"
-	}
+    "codex-proxy": {
+        "cargoLock": null,
+        "date": "2026-06-02",
+        "extract": null,
+        "name": "codex-proxy",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "jmmaloney4",
+            "repo": "codex-proxy",
+            "rev": "aa8d9032ff92ae984482f44818b509f72cd0d7b2",
+            "sha256": "sha256-q1UE3cCFsGqOdd4aljVX1QBw4zmVMEJnKcACigfHy64=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "aa8d9032ff92ae984482f44818b509f72cd0d7b2"
+    },
+    "gemini-proxy": {
+        "cargoLock": null,
+        "date": "2026-03-09",
+        "extract": null,
+        "name": "gemini-proxy",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "KashifKhn",
+            "repo": "gemini-proxy",
+            "rev": "5f701a244ed3c4699e6c1b0550bd50e961601ebe",
+            "sha256": "sha256-RYDeVd66AXHHbm7TzX8et8QUspvfjxpkq8o4VXh76Cw=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "5f701a244ed3c4699e6c1b0550bd50e961601ebe"
+    },
+    "mcp-ynab": {
+        "cargoLock": null,
+        "date": "2026-03-07",
+        "extract": null,
+        "name": "mcp-ynab",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "jmmaloney4",
+            "repo": "mcp-ynab",
+            "rev": "b7b21e4990fa824b24bb86f2f2d8fd053817f047",
+            "sha256": "sha256-Ukh5FvBmk5A4ol2IRpBvrWp1K6fcWDfxssiw0gJ9l84=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "b7b21e4990fa824b24bb86f2f2d8fd053817f047"
+    },
+    "nautilus-trader": {
+        "cargoLock": {
+            "Cargo.lock": [
+                "sha256-5NgHvKZoydlqxfMvXEjZy73g8kJGoIV2L7kRKnfkRXc=/Cargo.lock",
+                {}
+            ]
+        },
+        "date": "2026-05-29",
+        "extract": null,
+        "name": "nautilus-trader",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "nautechsystems",
+            "repo": "nautilus_trader",
+            "rev": "1408bec68bb01ba1c3166e1f3803f1536fc9c950",
+            "sha256": "sha256-5NgHvKZoydlqxfMvXEjZy73g8kJGoIV2L7kRKnfkRXc=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "1408bec68bb01ba1c3166e1f3803f1536fc9c950"
+    },
+    "spooktacular": {
+        "cargoLock": null,
+        "date": "2026-04-19",
+        "extract": null,
+        "name": "spooktacular",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "Spooky-Labs",
+            "repo": "spooktacular",
+            "rev": "f36634b84e1d38d81bd282b0f88a497557e4a520",
+            "sha256": "sha256-x8bqwvbw0WZKASEIDqCVR8b91RqJKSLYcNSfe68WzrE=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "f36634b84e1d38d81bd282b0f88a497557e4a520"
+    },
+    "tod": {
+        "cargoLock": {
+            "Cargo.lock": [
+                "sha256-091_1go_dBpTxK60Zh1cuzEJl7Fh7X7vpStRRoKFOzA=/Cargo.lock",
+                {}
+            ]
+        },
+        "date": null,
+        "extract": null,
+        "name": "tod",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "alanvardy",
+            "repo": "tod",
+            "rev": "v0.12.1",
+            "sha256": "sha256-091/1go/dBpTxK60Zh1cuzEJl7Fh7X7vpStRRoKFOzA=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "v0.12.1"
+    }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -4,18 +4,19 @@
   fetchurl,
   fetchFromGitHub,
   dockerTools,
-}: {
+}:
+{
   codex-proxy = {
     pname = "codex-proxy";
-    version = "0f453a3038fdef274d55dc8e9aaee0547495ff23";
+    version = "aa8d9032ff92ae984482f44818b509f72cd0d7b2";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy";
-      rev = "0f453a3038fdef274d55dc8e9aaee0547495ff23";
+      rev = "aa8d9032ff92ae984482f44818b509f72cd0d7b2";
       fetchSubmodules = false;
-      sha256 = "sha256-PfMZI7PmmpuvGRtEmy97wojsVO/snzuPtlZSLcJ7KYE=";
+      sha256 = "sha256-q1UE3cCFsGqOdd4aljVX1QBw4zmVMEJnKcACigfHy64=";
     };
-    date = "2026-05-29";
+    date = "2026-06-02";
   };
   gemini-proxy = {
     pname = "gemini-proxy";
@@ -54,6 +55,7 @@
     cargoLock."Cargo.lock" = {
       lockFile = ./. + "/sha256-5NgHvKZoydlqxfMvXEjZy73g8kJGoIV2L7kRKnfkRXc=/Cargo.lock";
       outputHashes = {
+        
       };
     };
     date = "2026-05-29";
@@ -83,6 +85,7 @@
     cargoLock."Cargo.lock" = {
       lockFile = ./. + "/sha256-091_1go_dBpTxK60Zh1cuzEJl7Fh7X7vpStRRoKFOzA=/Cargo.lock";
       outputHashes = {
+        
       };
     };
   };


### PR DESCRIPTION
## Summary

Bumps the `codex-proxy` source pin from `0f453a3` to `aa8d9032` (jmmaloney4/codex-proxy `main`).

This pulls in:
- **codex-proxy#4** — the non-streaming `/v1/chat/completions` path now reports the upstream Codex token usage instead of omitting it. Fixes zero token/cost attribution for the LiteLLM `coding`/`smart` tiers in Langfuse and Prometheus.
- **codex-proxy#1** — the `/admin/codex/usage` GET endpoint (already merged to fork `main`; previously lagging in the deployed image).

## Notes
- `go.mod`/`go.sum` are unchanged across this range, so **vendorHash is unaffected**.
- `nix build .#codex-proxy` succeeds with the existing vendorHash.
- The large line count in `_sources/generated.json` is a treefmt whitespace reformat; the only semantic change (verified via normalized `jq -S` diff) is codex-proxy's `rev`/`sha256`/`version`/`date`.

## Test plan
- `nvfetcher -c nvfetcher.toml --filter codex-proxy` produced the pin update.
- `nix build .#codex-proxy` ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and generated-file formatting only; no application logic in this repo changes.
> 
> **Overview**
> Updates the **nvfetcher** pin for `codex-proxy` to commit `aa8d9032` (from `0f453a3`), including new `rev`, `sha256`, `version`, and `date` in `_sources/generated.json` and `_sources/generated.nix`.
> 
> The deployed proxy build will pick up upstream fixes for **non-streaming** `/v1/chat/completions` token usage reporting and the `/admin/codex/usage` endpoint already on fork `main`. Other pinned sources are unchanged.
> 
> The diff also **reformats** `generated.json` (indentation) and makes small **cosmetic** edits to `generated.nix` (attribute-set layout, empty lines in `cargoLock` `outputHashes`); those do not change fetch semantics for other packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98734469f2ca9c7ab5f88294d748edd8db203963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->