### PR TITLE
feat(skopeo-nix2container): re-export skopeo-nix2container package

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ ______________________________________________________________________
 - `epub2tts` - EPUB -> TTS
 - `lean` - Lean theorem prover
 - `seedtool-cli` - SSKR seed tool CLI
+- `skopeo-nix2container` - skopeo with the `nix:` transport (re-exported from nix2container), for reading/pushing nix2container images
 - `tod` - Todoist CLI
 
 Build from CLI (examples):

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,14 @@
             python312 = pkgs.python314;
           };
           seedtool-cli = pkgs.callPackage ./pkgs/seedtool-cli {};
+          # Re-export skopeo-nix2container from the nix2container flake so it is
+          # built once and pushed to our binary cache, instead of every consumer
+          # rebuilding it from `github:nlewo/nix2container#...`. The tagged
+          # v1.0.0 release fetches a skopeo patch from a GitHub commit URL whose
+          # fixed-output hash GitHub has since broken, so building it fresh fails;
+          # our pinned input (HEAD) ships skopeo-1.21.0 without that patch.
+          # Consumed by sector7's image-push scripts to read/push nix images.
+          skopeo-nix2container = inputs.nix2container.packages.${system}.skopeo-nix2container;
           spooktacular = pkgs.callPackage ./pkgs/spooktacular {
             inherit (nvfetcherSources.spooktacular) src date;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
           # rebuilding it from `github:nlewo/nix2container#...`. The tagged
           # v1.0.0 release fetches a skopeo patch from a GitHub commit URL whose
           # fixed-output hash GitHub has since broken, so building it fresh fails;
-          # our pinned input (HEAD) ships skopeo-1.21.0 without that patch.
+          # our pinned input (HEAD) ships skopeo-1.22.2 without that patch.
           # Consumed by sector7's image-push scripts to read/push nix images.
           skopeo-nix2container = inputs.nix2container.packages.${system}.skopeo-nix2container;
           spooktacular = pkgs.callPackage ./pkgs/spooktacular {


### PR DESCRIPTION
## Summary

Adds `skopeo-nix2container` to jackpkgs by re-exporting it from the already-pinned `nix2container` flake input. This makes it available as `github:jmmaloney4/jackpkgs#skopeo-nix2container` and builds it in CI so it lands in our binary cache.

## Why

`skopeo-nix2container` is skopeo patched with the `nix:` transport — required to read/push nix2container-format images. Consumers (e.g. sector7's `nix-image-push.sh`) currently invoke `nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container`, which is broken:

- The tagged **v1.0.0** release builds **skopeo-1.11.1**, which applies a patch fetched from a GitHub commit URL. GitHub changed the byte content of generated `.patch` files, so the fixed-output hash now deterministically mismatches (`specified: sha256-dKEObf…` vs `got: sha256-1Tj9D+…`).
- That skopeo is **not in any public cache** (cache.nixos.org doesn't have it; nix2container's own cachix is gone — returns 401 "doesn't exist"), so it must build, and the build fails.

It only ever worked when skopeo happened to already be in the local store. This surfaced as a hard failure pushing the periscope stage image.

Our pinned `nix2container` input (HEAD) ships **skopeo-1.22.2** without that patch and builds cleanly. Re-exporting it here means it's built once and cached for all consumers.

## Changes

- `flake.nix`: add `skopeo-nix2container = inputs.nix2container.packages.${system}.skopeo-nix2container;` to perSystem `allPackages`.
- `README.md`: add it to the package list (per AGENTS.md).

## Test plan

- `nix eval .#packages.aarch64-darwin.skopeo-nix2container.name` → `skopeo-1.22.2`
- `nix build .#skopeo-nix2container` → builds successfully → `…-skopeo-1.22.2`
- Confirmed present in the filtered `packages` output.
- `nix fmt` clean.

## Follow-up (separate, not in this PR)

Point sector7's `nix-image-push.sh` / `nix-image-build-push.sh` at `github:jmmaloney4/jackpkgs#skopeo-nix2container` instead of `github:nlewo/nix2container/v1.0.0#…`, release sector7, and bump it in zeus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)