### PR TITLE
feat(pkgs): add codex-proxy-rs package

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -20,6 +20,27 @@
         },
         "version": "aa8d9032ff92ae984482f44818b509f72cd0d7b2"
     },
+    "codex-proxy-rs": {
+        "cargoLock": null,
+        "date": "2026-06-11",
+        "extract": null,
+        "name": "codex-proxy-rs",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "jmmaloney4",
+            "repo": "codex-proxy-rs",
+            "rev": "07f3d69095f4713d7a570349741e588d0b7f2e9d",
+            "sha256": "sha256-mmDCRaRRVALTEQj2DXPzCL4oBaXrLx6vXNE+VX6nppw=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "07f3d69095f4713d7a570349741e588d0b7f2e9d"
+    },
     "gemini-proxy": {
         "cargoLock": null,
         "date": "2026-03-09",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -18,6 +18,18 @@
     };
     date = "2026-06-02";
   };
+  codex-proxy-rs = {
+    pname = "codex-proxy-rs";
+    version = "07f3d69095f4713d7a570349741e588d0b7f2e9d";
+    src = fetchFromGitHub {
+      owner = "jmmaloney4";
+      repo = "codex-proxy-rs";
+      rev = "07f3d69095f4713d7a570349741e588d0b7f2e9d";
+      fetchSubmodules = false;
+      sha256 = "sha256-mmDCRaRRVALTEQj2DXPzCL4oBaXrLx6vXNE+VX6nppw=";
+    };
+    date = "2026-06-11";
+  };
   gemini-proxy = {
     pname = "gemini-proxy";
     version = "5f701a244ed3c4699e6c1b0550bd50e961601ebe";

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,9 @@
           codex-proxy = pkgs.callPackage ./pkgs/codex-proxy {
             inherit (nvfetcherSources.codex-proxy) src version;
           };
+          codex-proxy-rs = pkgs.callPackage ./pkgs/codex-proxy-rs {
+            inherit (nvfetcherSources.codex-proxy-rs) src version;
+          };
           docfx = pkgs.callPackage ./pkgs/docfx {};
           gemini-proxy = pkgsWithBun2nix.callPackage ./pkgs/gemini-proxy {
             inherit (nvfetcherSources.gemini-proxy) src version;

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -23,3 +23,7 @@ fetch.github = "KashifKhn/gemini-proxy"
 [mcp-ynab]
 src.git = "https://github.com/jmmaloney4/mcp-ynab"
 fetch.github = "jmmaloney4/mcp-ynab"
+
+[codex-proxy-rs]
+src.git = "https://github.com/jmmaloney4/codex-proxy-rs"
+fetch.github = "jmmaloney4/codex-proxy-rs"

--- a/overlay.nix
+++ b/overlay.nix
@@ -29,6 +29,9 @@ else let
     codex-proxy = super.callPackage ./pkgs/codex-proxy {
       inherit (nvfetcherSources.codex-proxy) src version;
     };
+    codex-proxy-rs = super.callPackage ./pkgs/codex-proxy-rs {
+      inherit (nvfetcherSources.codex-proxy-rs) src version;
+    };
     docfx = super.callPackage ./pkgs/docfx {};
     gemini-proxy = superWithBun2nix.callPackage ./pkgs/gemini-proxy {
       inherit (nvfetcherSources.gemini-proxy) src version;

--- a/pkgs/codex-proxy-rs/default.nix
+++ b/pkgs/codex-proxy-rs/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  # From nvfetcher
+  src,
+  version,
+}:
+rustPlatform.buildRustPackage {
+  pname = "codex-proxy-rs";
+  inherit version src;
+
+  # The crate ships its own Cargo.lock and depends only on crates.io
+  # registry packages (no git dependencies), so the lockfile can be read
+  # straight from the fetched source with no outputHashes.
+  cargoLock.lockFile = src + "/Cargo.lock";
+
+  # Integration tests bind localhost, which the sandbox forbids; the
+  # devshell runs them via cargo-nextest instead.
+  doCheck = false;
+
+  meta = {
+    description = "Rust port of codex-proxy: OpenAI-compatible reverse proxy for the ChatGPT Codex backend";
+    homepage = "https://github.com/jmmaloney4/codex-proxy-rs";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "codex-proxy";
+  };
+}


### PR DESCRIPTION
## Summary

Adds a `codex-proxy-rs` package — the Rust port of codex-proxy (an OpenAI-compatible reverse proxy for the ChatGPT Codex backend), sourced from [jmmaloney4/codex-proxy-rs](https://github.com/jmmaloney4/codex-proxy-rs).

- **nvfetcher.toml**: new `[codex-proxy-rs]` entry tracking the repo's default-branch HEAD via `src.git` (the repo has no GitHub releases, so the release-tracking `src.github` form 404s).
- **_sources/generated.{nix,json}**: regenerated entry pinned at `07f3d69`.
- **pkgs/codex-proxy-rs/default.nix**: `rustPlatform.buildRustPackage`. Reads `Cargo.lock` directly from the fetched `src` — all deps are crates.io registry packages (no git deps), so no `outputHashes` and no force-added lockfile under the gitignored `_sources/`. `doCheck = false` because the integration tests bind localhost, which the Nix sandbox forbids.
- **overlay.nix** + **flake.nix**: registered in both `allPackages` maps, mirroring the existing `codex-proxy` entry.

Note: the source repo `jmmaloney4/codex-proxy-rs` was flipped private → public so `fetchFromGitHub` can fetch it in the sandbox without a token (matching every other jackpkgs source).

## Test plan

- `nvfetcher` regenerates the source entry cleanly (unrelated nautilus-trader auto-bump was reverted to keep this PR scoped).
- `nix build .#codex-proxy-rs` succeeds.
- `nix eval .#codex-proxy-rs.pname` → `"codex-proxy-rs"`.
- Built binary runs: `codex-proxy --help` prints the expected usage.
- `alejandra` reports the new/edited Nix files compliant.

## Risks

- The crate's binary is named `codex-proxy` (same as the existing Go `codex-proxy` package). The package *attrs* differ (`codex-proxy` vs `codex-proxy-rs`), so this only collides if both are installed into the same profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)