### PR TITLE
chore(codex-proxy-rs): bump to 66d63ef (gpt-5.4-mini support)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -22,7 +22,7 @@
     },
     "codex-proxy-rs": {
         "cargoLock": null,
-        "date": "2026-06-11",
+        "date": "2026-06-12",
         "extract": null,
         "name": "codex-proxy-rs",
         "passthru": null,
@@ -34,12 +34,12 @@
             "name": null,
             "owner": "jmmaloney4",
             "repo": "codex-proxy-rs",
-            "rev": "07f3d69095f4713d7a570349741e588d0b7f2e9d",
-            "sha256": "sha256-mmDCRaRRVALTEQj2DXPzCL4oBaXrLx6vXNE+VX6nppw=",
+            "rev": "66d63ef74c64bf222e0d15916b75676f3f590f13",
+            "sha256": "sha256-S2c6qj2OmbmerA/PkbQVcLrPPWhqs5rRs/cIAzxgpXs=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "07f3d69095f4713d7a570349741e588d0b7f2e9d"
+        "version": "66d63ef74c64bf222e0d15916b75676f3f590f13"
     },
     "gemini-proxy": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,15 +20,15 @@
   };
   codex-proxy-rs = {
     pname = "codex-proxy-rs";
-    version = "07f3d69095f4713d7a570349741e588d0b7f2e9d";
+    version = "66d63ef74c64bf222e0d15916b75676f3f590f13";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy-rs";
-      rev = "07f3d69095f4713d7a570349741e588d0b7f2e9d";
+      rev = "66d63ef74c64bf222e0d15916b75676f3f590f13";
       fetchSubmodules = false;
-      sha256 = "sha256-mmDCRaRRVALTEQj2DXPzCL4oBaXrLx6vXNE+VX6nppw=";
+      sha256 = "sha256-S2c6qj2OmbmerA/PkbQVcLrPPWhqs5rRs/cIAzxgpXs=";
     };
-    date = "2026-06-11";
+    date = "2026-06-12";
   };
   gemini-proxy = {
     pname = "gemini-proxy";


### PR DESCRIPTION
## Summary

Bumps the `codex-proxy-rs` source pin `07f3d69` → `66d63ef`, picking up [jmmaloney4/codex-proxy-rs#8](https://github.com/jmmaloney4/codex-proxy-rs/pull/8) — which adds **`gpt-5.4-mini`** as a first-class model. Previously codex-proxy normalized `gpt-5.4-mini` to full `gpt-5.4` (substring-ordering bug); now it passes through.

Only the `codex-proxy-rs` entry in `_sources/generated.{nix,json}` changed (nvfetcher's incidental `nautilus-trader` re-check was reverted to keep this scoped).

## Test plan
- `nix build .#codex-proxy-rs` succeeds at the new rev (`66d63ef`).
- The built binary embeds `gpt-5.4-mini` (verified in `/v1/models` data).

## Context
Middle link in the chain: codex-proxy-rs#8 (merged) → **this** → garden cheap-tier rewrite (glm-4.7 50% / gpt-5.4-mini 50%, qwen fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)