### PR TITLE
ci(nix): wire attic binary cache into sector7 reusable workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,4 +20,7 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      # Only forward the push-capable cache token on trusted events so PR runs
+      # can read from the cache but not push to it. Empty string makes the
+      # sector7 reusable workflow's push steps fall back to read-only mode.
+      BINARY_CACHE_TOKEN: ${{ github.event_name == 'push' && secrets.ATTIC_CACHE_TOKEN || '' }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,3 +15,9 @@ jobs:
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
+      binary-cache-url: ${{ vars.ATTIC_CACHE_URL }}
+      binary-cache-public-key: ${{ vars.ATTIC_CACHE_PUBLIC_KEY }}
+      binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
+      binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
+    secrets:
+      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,7 +20,8 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      # Only forward the push-capable cache token on trusted events so PR runs
-      # can read from the cache but not push to it. Empty string makes the
-      # sector7 reusable workflow's push steps fall back to read-only mode.
-      BINARY_CACHE_TOKEN: ${{ github.event_name == 'push' && secrets.ATTIC_CACHE_TOKEN || '' }}
+      # Forward the push-capable cache token only on trusted events (push,
+      # workflow_dispatch). PR runs read from the cache via the substituter
+      # but cannot push, eliminating cache poisoning / token exfiltration
+      # risk from PR-triggered builds.
+      BINARY_CACHE_TOKEN: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.ATTIC_CACHE_TOKEN || '' }}


### PR DESCRIPTION
## Summary

- Pass the \`ATTIC_*\` repo vars and \`ATTIC_CACHE_TOKEN\` secret through to \`jmmaloney4/sector7/.github/workflows/nix.yml\` as \`binary-cache-*\` inputs and \`BINARY_CACHE_TOKEN\`.
- Without this, every nix CI job runs uncached: \`nix-eval-jobs\` has to evaluate locally and every build is from source.
- The vars/secret are already provisioned on this repo by the garden Pulumi stack (\`deploy/services/attic\`); the workflow just wasn't wired up.

Same fix that just landed for \`cavinsresearch/zeus\` ([commit 651353e5](https://github.com/cavinsresearch/zeus/commit/651353e5)).

## Test plan

- [ ] Trigger the workflow (push or workflow_dispatch) and confirm \`nix-eval-jobs\` skips already-cached store paths instead of re-evaluating from scratch.
- [ ] Confirm the \`attic watch-store\` step starts in the \`detect\` job logs.
- [ ] Confirm the \`Push built store paths to binary cache\` step runs after each build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)