### PR TITLE
ci(nix): collapse justfile/module/pnpm checks into one fixture-tests check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -235,6 +235,132 @@
               '';
             }
             // extraAttrs);
+
+        # pnpm integration fixtures. Each is a full build (pnpm install + checkCommand),
+        # aggregated into the single `fixture-tests` check below rather than exposed
+        # individually.
+        pnpmFixtureChecks = {
+          pnpm-simple-builds = mkPnpmFixtureCheck {
+            name = "simple-pnpm";
+            src = fixtureSimplePnpm;
+            depsHash = "sha256-R0X9msP0FeYEOnoO5rDwpykuj7FgWqEM8cGvZHwrvOc=";
+            checkCommand = ''
+              test -d node_modules
+              node index.js | grep -qx "pass"
+            '';
+          };
+
+          pnpm-workspace-basic-postinstall = mkPnpmFixtureCheck {
+            name = "workspace-basic";
+            src = fixtureWorkspaceBasic;
+            depsHash = "sha256-7t46ZAfJERoP/gCEIyqubbo3Ob3RLHW6NTDr1a5nnCw=";
+            checkCommand = ''
+              test -d node_modules
+              pnpm run postinstall
+              test -f lib/dist/index.js
+              node --input-type=module -e "const lib = await import('./lib/dist/index.js'); if (lib.add(2, 3) !== 5) process.exit(1);"
+            '';
+          };
+
+          pnpm-workspace-glob-resolution = mkPnpmFixtureCheck {
+            name = "workspace-glob";
+            src = fixtureWorkspaceGlob;
+            depsHash = "sha256-gIL4zhfAcMT3U0PIUAO4bBQk0EBXiGs0quYO3zm1DXU=";
+            checkCommand = ''
+              test -d node_modules
+              node packages/beta/index.js | grep -qx "hello from alpha"
+            '';
+          };
+
+          pnpm-tsc-check = mkPnpmFixtureCheck {
+            name = "tsc-check";
+            src = fixtureTscCheck;
+            depsHash = "sha256-7t46ZAfJERoP/gCEIyqubbo3Ob3RLHW6NTDr1a5nnCw=";
+            checkCommand = ''
+              test -d node_modules
+              node_modules/.bin/tsc --noEmit --lib ES2020,DOM packages/app/index.ts
+            '';
+          };
+
+          pnpm-vitest-check = mkPnpmFixtureCheck {
+            name = "vitest-check";
+            src = fixtureVitestCheck;
+            depsHash = "sha256-VgoszjnpdXC3uhzjGWIjv7W6BQgT8uldbSkgHu8S4RI=";
+            checkCommand = ''
+              test -d node_modules
+              node_modules/.bin/vitest run --root packages/lib
+            '';
+          };
+
+          pnpm-node-modules-output-layout = mkPnpmFixtureCheck {
+            name = "node-modules-output-layout";
+            src = fixtureWorkspaceBasic;
+            depsHash = "sha256-7t46ZAfJERoP/gCEIyqubbo3Ob3RLHW6NTDr1a5nnCw=";
+            checkCommand = ''
+              mkdir -p "$out"
+              cp -a node_modules "$out/"
+              test -d "$out/node_modules"
+              test -L "$out/node_modules/.pnpm/node_modules/@test/lib"
+              test ! -e "$out/node_modules/.pnpm/node_modules/@test/lib"
+            '';
+            extraAttrs = {
+              dontCheckForBrokenSymlinks = true;
+            };
+          };
+
+          pnpm-nonhoisted-runtime = mkPnpmFixtureCheck {
+            name = "nonhoisted-runtime";
+            src = fixtureNonhoistedDep;
+            depsHash = "sha256-R0X9msP0FeYEOnoO5rDwpykuj7FgWqEM8cGvZHwrvOc=";
+            checkCommand = ''
+              test -d node_modules
+              node packages/app/index.js | grep -qx "pass"
+            '';
+          };
+
+          # Mirrors nodejs.nix:125-129 installPhase; keep in sync.
+          pnpm-nonhoisted-output-layout = mkPnpmFixtureCheck {
+            name = "nonhoisted-output-layout";
+            src = fixtureNonhoistedDep;
+            depsHash = "sha256-R0X9msP0FeYEOnoO5rDwpykuj7FgWqEM8cGvZHwrvOc=";
+            checkCommand = ''
+              mkdir -p "$out"
+              cp -a node_modules "$out/"
+              find . -mindepth 2 -name 'node_modules' -type d \
+                -not -path './node_modules/*' | while read -r dir; do
+                mkdir -p "$out/$(dirname "$dir")"
+                cp -a "$dir" "$out/$dir"
+              done
+
+              test -d "$out/node_modules"
+              test ! -e "$out/node_modules/is-odd"
+              test -L "$out/packages/app/node_modules/is-odd"
+              test -z "$(find "$out/node_modules/.pnpm" -path '*/node_modules/node_modules' -print -quit)"
+            '';
+            extraAttrs = {
+              dontCheckForBrokenSymlinks = true;
+            };
+          };
+        };
+
+        # Combined set of fixture-style tests (justfile parser validation, module
+        # recipe patterns, and pnpm integration fixtures). Each value is a derivation;
+        # the keys preserve the old check names for debugging via `passthru`.
+        fixtureTests =
+          lib.mapAttrs' (name: test: lib.nameValuePair "justfile-${name}" test) justfileValidationTests
+          // lib.mapAttrs' (name: test: lib.nameValuePair "module-${name}" test) moduleJustfileTests
+          // pnpmFixtureChecks;
+
+        # A single aggregate check that depends on every fixture test, collapsing what
+        # used to be ~32 individual CI checks into one. Building this forces all
+        # sub-derivations to build; any failure fails the aggregate. Individual tests
+        # remain reachable for debugging, e.g.
+        #   nix build .#checks.<system>.fixture-tests.justfile-testSingleRecipe
+        fixtureTestsCheck = pkgs.runCommand "fixture-tests" {passthru = fixtureTests;} ''
+          echo "Aggregated fixture tests (justfile + module + pnpm):"
+          ${lib.concatMapStringsSep "\n" (name: "echo '  ✅ ${name}: ${fixtureTests.${name}}'") (builtins.attrNames fixtureTests)}
+          touch "$out"
+        '';
       in {
         # Make jackLib and platformFilteredPackages available for devShell
         _module.args.jackpkgs =
@@ -325,114 +451,11 @@
           };
         };
 
-        checks =
-          # Add all justfile validation tests
-          lib.mapAttrs' (name: test: lib.nameValuePair "justfile-${name}" test) justfileValidationTests
-          # Add module pattern tests
-          // lib.mapAttrs' (name: test: lib.nameValuePair "module-${name}" test) moduleJustfileTests
-          // {
-            pnpm-simple-builds = mkPnpmFixtureCheck {
-              name = "simple-pnpm";
-              src = fixtureSimplePnpm;
-              depsHash = "sha256-R0X9msP0FeYEOnoO5rDwpykuj7FgWqEM8cGvZHwrvOc=";
-              checkCommand = ''
-                test -d node_modules
-                node index.js | grep -qx "pass"
-              '';
-            };
-
-            pnpm-workspace-basic-postinstall = mkPnpmFixtureCheck {
-              name = "workspace-basic";
-              src = fixtureWorkspaceBasic;
-              depsHash = "sha256-7t46ZAfJERoP/gCEIyqubbo3Ob3RLHW6NTDr1a5nnCw=";
-              checkCommand = ''
-                test -d node_modules
-                pnpm run postinstall
-                test -f lib/dist/index.js
-                node --input-type=module -e "const lib = await import('./lib/dist/index.js'); if (lib.add(2, 3) !== 5) process.exit(1);"
-              '';
-            };
-
-            pnpm-workspace-glob-resolution = mkPnpmFixtureCheck {
-              name = "workspace-glob";
-              src = fixtureWorkspaceGlob;
-              depsHash = "sha256-gIL4zhfAcMT3U0PIUAO4bBQk0EBXiGs0quYO3zm1DXU=";
-              checkCommand = ''
-                test -d node_modules
-                node packages/beta/index.js | grep -qx "hello from alpha"
-              '';
-            };
-
-            pnpm-tsc-check = mkPnpmFixtureCheck {
-              name = "tsc-check";
-              src = fixtureTscCheck;
-              depsHash = "sha256-7t46ZAfJERoP/gCEIyqubbo3Ob3RLHW6NTDr1a5nnCw=";
-              checkCommand = ''
-                test -d node_modules
-                node_modules/.bin/tsc --noEmit --lib ES2020,DOM packages/app/index.ts
-              '';
-            };
-
-            pnpm-vitest-check = mkPnpmFixtureCheck {
-              name = "vitest-check";
-              src = fixtureVitestCheck;
-              depsHash = "sha256-VgoszjnpdXC3uhzjGWIjv7W6BQgT8uldbSkgHu8S4RI=";
-              checkCommand = ''
-                test -d node_modules
-                node_modules/.bin/vitest run --root packages/lib
-              '';
-            };
-
-            pnpm-node-modules-output-layout = mkPnpmFixtureCheck {
-              name = "node-modules-output-layout";
-              src = fixtureWorkspaceBasic;
-              depsHash = "sha256-7t46ZAfJERoP/gCEIyqubbo3Ob3RLHW6NTDr1a5nnCw=";
-              checkCommand = ''
-                mkdir -p "$out"
-                cp -a node_modules "$out/"
-                test -d "$out/node_modules"
-                test -L "$out/node_modules/.pnpm/node_modules/@test/lib"
-                test ! -e "$out/node_modules/.pnpm/node_modules/@test/lib"
-              '';
-              extraAttrs = {
-                dontCheckForBrokenSymlinks = true;
-              };
-            };
-
-            pnpm-nonhoisted-runtime = mkPnpmFixtureCheck {
-              name = "nonhoisted-runtime";
-              src = fixtureNonhoistedDep;
-              depsHash = "sha256-R0X9msP0FeYEOnoO5rDwpykuj7FgWqEM8cGvZHwrvOc=";
-              checkCommand = ''
-                test -d node_modules
-                node packages/app/index.js | grep -qx "pass"
-              '';
-            };
-
-            # Mirrors nodejs.nix:125-129 installPhase; keep in sync.
-            pnpm-nonhoisted-output-layout = mkPnpmFixtureCheck {
-              name = "nonhoisted-output-layout";
-              src = fixtureNonhoistedDep;
-              depsHash = "sha256-R0X9msP0FeYEOnoO5rDwpykuj7FgWqEM8cGvZHwrvOc=";
-              checkCommand = ''
-                mkdir -p "$out"
-                cp -a node_modules "$out/"
-                find . -mindepth 2 -name 'node_modules' -type d \
-                  -not -path './node_modules/*' | while read -r dir; do
-                  mkdir -p "$out/$(dirname "$dir")"
-                  cp -a "$dir" "$out/$dir"
-                done
-
-                test -d "$out/node_modules"
-                test ! -e "$out/node_modules/is-odd"
-                test -L "$out/packages/app/node_modules/is-odd"
-                test -z "$(find "$out/node_modules/.pnpm" -path '*/node_modules/node_modules' -print -quit)"
-              '';
-              extraAttrs = {
-                dontCheckForBrokenSymlinks = true;
-              };
-            };
-          };
+        # All justfile, module, and pnpm fixture tests collapse into one CI check.
+        # See `fixtureTests` / `fixtureTestsCheck` above for the aggregation.
+        checks = {
+          fixture-tests = fixtureTestsCheck;
+        };
       };
 
       flake = {


### PR DESCRIPTION
## Summary

CI currently surfaces ~32 individual checks for what are really three groups of fixture-style tests:

- `justfile-*` (14) — run the `just` parser to validate generated justfile syntax
- `module-*` (10) — same parser validation for module recipe patterns
- `pnpm-*` (8) — pnpm integration fixtures (install + tsc/vitest/runtime assertions)

Despite living in `tests/`, these are **derivation-based** tests, not nix-unit `expr`/`expected` cases, so they never folded into the already-aggregated `nix-unit` check and each one became its own CI check.

This PR aggregates all three groups into a single **`fixture-tests`** check:

- Moves the 8 inline `pnpm-*` definitions into a `pnpmFixtureChecks` let-binding.
- Builds a combined `fixtureTests` attrset (justfile + module + pnpm), preserving the original names as keys.
- Adds one `fixture-tests` aggregate derivation that depends on every sub-test — building it builds them all, and any single failure fails the check.
- Keeps each sub-test reachable via `passthru` for debugging.

`nix flake check` now exposes **4 checks instead of ~34**:

\`\`\`
fixture-tests   nix-unit   pre-commit   treefmt
\`\`\`

## Test plan

- `nix eval .#checks.aarch64-darwin --apply builtins.attrNames` → `[ "fixture-tests" "nix-unit" "pre-commit" "treefmt" ]` ✅
- `nix build .#checks.aarch64-darwin.fixture-tests.justfile-testComplexJustfile .#checks.aarch64-darwin.fixture-tests.module-testAuthStatus` → builds green via passthru ✅
- Aggregate wiring confirmed: building `fixture-tests` correctly fans out to all 32 sub-derivations and fails the aggregate when one fails.
- `nix fmt` clean.

## Risks

- **Lost per-fixture granularity in the CI checks list** — a failure now shows as `fixture-tests` failing rather than the specific `pnpm-vitest-check`. Mitigated by: the aggregate's build log echoes each test name, and every sub-test stays individually buildable via `passthru` (`nix build .#checks.<system>.fixture-tests.<name>`).
- The `pnpm-*` fixtures could not be fully built locally on darwin (`fetchPnpmDeps` gets `Killed: 9` — pnpm fetcher needs network, blocked by the local build sandbox). This is a pre-existing environmental limitation noted in ADR-014; these run in CI. The aggregation wiring itself is verified correct (it correctly propagated that failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)