### PR TITLE
feat(codex-proxy-rs): bump to main @ 8ffb295 (OTLP trace export)

### DIFF
--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,15 +20,15 @@
   };
   codex-proxy-rs = {
     pname = "codex-proxy-rs";
-    version = "66d63ef74c64bf222e0d15916b75676f3f590f13";
+    version = "8ffb2959572c4b09f33aa1da40f59362414c51e0";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy-rs";
-      rev = "66d63ef74c64bf222e0d15916b75676f3f590f13";
+      rev = "8ffb2959572c4b09f33aa1da40f59362414c51e0";
       fetchSubmodules = false;
-      sha256 = "sha256-S2c6qj2OmbmerA/PkbQVcLrPPWhqs5rRs/cIAzxgpXs=";
+      sha256 = "sha256-pQ7y6tAtPj+ZOOOvh1bfBY1bum5qXdmtRwl07+P9F28=";
     };
-    date = "2026-06-12";
+    date = "2026-06-14";
   };
   gemini-proxy = {
     pname = "gemini-proxy";


### PR DESCRIPTION
## Summary
Re-pin `codex-proxy-rs` to latest `main` (`8ffb295`), which includes [codex-proxy-rs #9](https://github.com/jmmaloney4/codex-proxy-rs/pull/9) — OpenTelemetry OTLP trace export (ADR 005).

**Why it's needed:** garden's `images.codex-proxy` is built from this package (`nix/flake-images.nix` → `jackpkgs.packages.*.codex-proxy-rs`). The source was pinned at `66d63ef` (Jun 12, pre-OTLP). Garden [#857](https://github.com/jmmaloney4/garden/pull/857) just wired `OTEL_*` env into the codex-proxy pods — but without this bump the deployed binary predates the OTLP code and ignores that env, so tracing would silently do nothing.

## What changed
Only the `codex-proxy-rs` entry in `_sources/generated.nix` — `rev`/`sha256`/`version`/`date` → `8ffb295`.

Updated **surgically** rather than via a full `nvfetcher` run: nvfetcher currently fails on the unrelated `tod` entry's `Cargo.lock` extraction (`nvfetcher-extract/Cargo.lock` missing — pre-existing, there are active worktrees fixing hash issues), and its `-f` filter still evaluates that oracle. The four updated fields are exactly what nvfetcher would emit; the hash was computed with `nix-prefetch-github`.

## Validation
`nix build .#codex-proxy-rs` ✅ — confirms the source hash fetches **and** the new OTel-dependency `Cargo.lock` vendors + compiles in the nix sandbox (no git deps; all crates.io, read via `cargoLock.lockFile`).

## Follow-up
garden [#XXX] bumps its `flake.lock` jackpkgs input to this PR's merged rev — that moves the image rebuild trigger so the codex-proxy pods roll onto the OTLP binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)