### PR TITLE
feat(just): add fix-tarball-integrity recipe to nodejs just module

### DIFF
--- a/modules/flake-parts/just.nix
+++ b/modules/flake-parts/just.nix
@@ -758,6 +758,47 @@ in {
           nodejs = {
             enable = cfg.nodejs.enable;
             justfile = lib.concatStringsSep "\n" [
+              (mkRecipe "fix-tarball-integrity" "Restore sha512 integrity on GitHub tarball resolutions that pnpm strips from pnpm-lock.yaml" [
+                  "#!/usr/bin/env bash"
+                  "set -euo pipefail"
+                  "lockfile=\"pnpm-lock.yaml\""
+                  "fixed=0"
+                  ''
+                    backup=$(mktemp)
+                    cp "$lockfile" "$backup"
+                    trap 'rc=$?; if [ $rc -ne 0 ]; then echo "❌ Restoring lockfile from backup..."; mv "$backup" "$lockfile"; else rm -f "$backup"; fi' EXIT
+
+                      while IFS= read -r line; do
+                          url=$(printf '%s' "$line" | sed -n 's/.*resolution: {tarball: \([^}]*\)}.*/\1/p')
+                          if [ -z "$url" ]; then continue; fi
+                          if ! printf '%s' "$url" | grep -qE '^https://(github\.com|codeload\.github\.com)/'; then
+                              echo "❌ Refusing to fetch non-GitHub URL: $url"
+                              exit 1
+                          fi
+                          echo "🔐 Computing integrity for $(basename "$url")..."
+                          tmpfile=$(mktemp)
+                          curl -sfL "$url" -o "$tmpfile"
+                          if ! tar -tf "$tmpfile" >/dev/null 2>&1; then
+                              echo "❌ Downloaded file is not a valid archive (URL may be wrong or rate-limited)"
+                              head -5 "$tmpfile"
+                              rm -f "$tmpfile"
+                              exit 1
+                          fi
+                          hash=$(openssl dgst -sha512 -binary "$tmpfile" | base64 | tr -d '\n')
+                          rm -f "$tmpfile"
+                          printf '✅  sha512-%s\n' "$hash"
+                          safe_url=$(printf '%s' "$url" | sed 's/[&\\]/\\&/g')
+                          perl -pi -e "s|resolution: \{tarball: \Q$url\E\}|resolution: {integrity: sha512-$hash, tarball: $safe_url}|" "$lockfile"
+                          fixed=$((fixed + 1))
+                      done < <(grep 'resolution: {tarball:' "$lockfile" | grep -v 'integrity:')
+                      if [ "$fixed" -eq 0 ]; then
+                          echo "✅ All tarball entries already have integrity hashes"
+                      else
+                          echo "✅ Fixed $fixed tarball entr$([ $fixed -eq 1 ] && echo 'y' || echo 'ies')"
+                      fi
+                  ''
+                ]
+                false)
               (mkRecipe "update-pnpm-hash" "Refresh pnpm-lock.yaml and update pnpmDepsHash in flake.nix" [
                   "#!/usr/bin/env bash"
                   "set -euo pipefail"
@@ -772,6 +813,9 @@ in {
                   ""
                   "echo \"📦 Running pnpm install to refresh pnpm-lock.yaml...\""
                   "pnpm install"
+                  ""
+                  "echo \"🔐 Restoring tarball integrity hashes...\""
+                  "just fix-tarball-integrity"
                   ""
                   "system=$(nix eval --raw --impure --expr 'builtins.currentSystem')"
                   "echo \"🔍 Detecting system: $system\""

--- a/tests/module-justfiles.nix
+++ b/tests/module-justfiles.nix
@@ -88,6 +88,46 @@ in {
 
   # Test Node.js pnpm hash update recipe pattern
   testNodejsUpdatePnpmHash = mkJustParseTest "nodejs-update-pnpm-hash" ''
+    # Restore sha512 integrity on GitHub tarball resolutions that pnpm strips from pnpm-lock.yaml
+    fix-tarball-integrity:
+        #!/usr/bin/env bash
+        set -euo pipefail
+        lockfile="pnpm-lock.yaml"
+        fixed=0
+
+        backup=$(mktemp)
+        cp "$lockfile" "$backup"
+        trap 'rc=$?; if [ $rc -ne 0 ]; then echo "❌ Restoring lockfile from backup..."; mv "$backup" "$lockfile"; else rm -f "$backup"; fi' EXIT
+
+        while IFS= read -r line; do
+            url=$(printf '%s' "$line" | sed -n 's/.*resolution: {tarball: \([^}]*\)}.*/\1/p')
+            if [ -z "$url" ]; then continue; fi
+            if ! printf '%s' "$url" | grep -qE '^https://(github\.com|codeload\.github\.com)/'; then
+                echo "❌ Refusing to fetch non-GitHub URL: $url"
+                exit 1
+            fi
+            echo "🔐 Computing integrity for $(basename "$url")..."
+            tmpfile=$(mktemp)
+            curl -sfL "$url" -o "$tmpfile"
+            if ! tar -tf "$tmpfile" >/dev/null 2>&1; then
+                echo "❌ Downloaded file is not a valid archive (URL may be wrong or rate-limited)"
+                head -5 "$tmpfile"
+                rm -f "$tmpfile"
+                exit 1
+            fi
+            hash=$(openssl dgst -sha512 -binary "$tmpfile" | base64 | tr -d '\n')
+            rm -f "$tmpfile"
+            printf '✅  sha512-%s\n' "$hash"
+            safe_url=$(printf '%s' "$url" | sed 's/[&\\]/\\&/g')
+            perl -pi -e "s|resolution: \{tarball: \Q$url\E\}|resolution: {integrity: sha512-$hash, tarball: $safe_url}|" "$lockfile"
+            fixed=$((fixed + 1))
+        done < <(grep 'resolution: {tarball:' "$lockfile" | grep -v 'integrity:')
+        if [ "$fixed" -eq 0 ]; then
+            echo "✅ All tarball entries already have integrity hashes"
+        else
+            echo "✅ Fixed $fixed tarball entr$([ $fixed -eq 1 ] && echo 'y' || echo 'ies')"
+        fi
+
     # Refresh pnpm-lock.yaml and update pnpmDepsHash in flake.nix
     update-pnpm-hash:
         #!/usr/bin/env bash
@@ -103,6 +143,9 @@ in {
 
         echo "📦 Running pnpm install to refresh pnpm-lock.yaml..."
         pnpm install
+
+        echo "🔐 Restoring tarball integrity hashes..."
+        just fix-tarball-integrity
 
         system=$(nix eval --raw --impure --expr 'builtins.currentSystem')
 


### PR DESCRIPTION
## Problem

pnpm strips the `integrity` field from GitHub-release tarball resolutions during lockfile regeneration. This causes `ERR_PNPM_MISSING_TARBALL_INTEGRITY` on fresh installs (`pnpm install --frozen-lockfile`) or `--update-checksums`. Recurs on every sector7 (or any GitHub-tarball dep) version bump across all repos.

## Solution

Add a `fix-tarball-integrity` just recipe to the jackpkgs nodejs just module:

1. Scans `pnpm-lock.yaml` for `resolution: {tarball: ...}` entries missing `integrity`
2. Downloads each tarball, computes `sha512-<base64>`, patches the lockfile inline
3. Also callable standalone: `just fix-tarball-integrity`

Wired into `update-pnpm-hash` so the standard `just update-pnpm-deps` workflow is now self-healing:

```
1. pnpm install                      (regenerates lockfile, strips integrity)
2. just fix-tarball-integrity        (restores integrity hashes)
3. nix build .#pnpm-deps             (FOD hash computation with clean lockfile)
```

## Test plan

- [x] nix-unit: 165/165 pass (incl. nodejs-update-pnpm-hash justfile parse test updated)
- [x] treefmt: clean
- [x] Manually tested the recipe in zeus — restored the exact sha512 hash that was hand-computed earlier
- [ ] fixture-tests: blocked by nodejs_24 worker_threads SIGKILL bug (nixpkgs#525627) — pre-existing, unrelated
