### PR TITLE
feat(codex-proxy-rs): bump to main @ bdd7d8c (buffered reasoning_content fix)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -22,7 +22,7 @@
     },
     "codex-proxy-rs": {
         "cargoLock": null,
-        "date": "2026-06-12",
+        "date": "2026-06-17",
         "extract": null,
         "name": "codex-proxy-rs",
         "passthru": null,
@@ -34,12 +34,12 @@
             "name": null,
             "owner": "jmmaloney4",
             "repo": "codex-proxy-rs",
-            "rev": "66d63ef74c64bf222e0d15916b75676f3f590f13",
-            "sha256": "sha256-S2c6qj2OmbmerA/PkbQVcLrPPWhqs5rRs/cIAzxgpXs=",
+            "rev": "bdd7d8cb8f3157b66a687445afbedf134d19635f",
+            "sha256": "sha256-Wgt59weDUiiYrtXHrHPQVdsJ5dEVWbZQwAMfOGBMank=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "66d63ef74c64bf222e0d15916b75676f3f590f13"
+        "version": "bdd7d8cb8f3157b66a687445afbedf134d19635f"
     },
     "gemini-proxy": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,15 +20,15 @@
   };
   codex-proxy-rs = {
     pname = "codex-proxy-rs";
-    version = "8ffb2959572c4b09f33aa1da40f59362414c51e0";
+    version = "bdd7d8cb8f3157b66a687445afbedf134d19635f";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy-rs";
-      rev = "8ffb2959572c4b09f33aa1da40f59362414c51e0";
+      rev = "bdd7d8cb8f3157b66a687445afbedf134d19635f";
       fetchSubmodules = false;
-      sha256 = "sha256-pQ7y6tAtPj+ZOOOvh1bfBY1bum5qXdmtRwl07+P9F28=";
+      sha256 = "sha256-Wgt59weDUiiYrtXHrHPQVdsJ5dEVWbZQwAMfOGBMank=";
     };
-    date = "2026-06-14";
+    date = "2026-06-17";
   };
   gemini-proxy = {
     pname = "gemini-proxy";


### PR DESCRIPTION
## Summary

Bumps the `codex-proxy-rs` nvfetcher pin from `8ffb295` → `bdd7d8c` (current `main`), picking up two merged upstream PRs:

- **codex-proxy-rs#12** — `fix(buffered)`: non-streaming chat completions now aggregate `reasoning_content` (the streaming path already did). Closes codex-proxy-rs#10.
- **codex-proxy-rs#11** — ADR 006 (docs only): conversation-scoped state design (account affinity + reasoning persistence).

## Change
- `_sources/generated.{nix,json}` regenerated via `nvfetcher --filter '^codex-proxy-rs$'` — only the `codex-proxy-rs` entry changed (rev + sha256 + date). No other package touched.
- No `Cargo.lock` / dependency changes upstream, so `cargoLock.lockFile` resolution is unaffected.

## Test plan
- `nix build .#codex-proxy-rs -L` builds clean from the new source; `result/bin/codex-proxy --version` → `codex-proxy 0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)