### PR TITLE
feat(codex-proxy-rs): bump to main @ dbf0232 (ADR 006 foundation)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -34,12 +34,12 @@
             "name": null,
             "owner": "jmmaloney4",
             "repo": "codex-proxy-rs",
-            "rev": "bdd7d8cb8f3157b66a687445afbedf134d19635f",
-            "sha256": "sha256-Wgt59weDUiiYrtXHrHPQVdsJ5dEVWbZQwAMfOGBMank=",
+            "rev": "dbf02325347ef49160c95eaebf6f5e4be83f79a9",
+            "sha256": "sha256-0piqRoveYyYru9zfX67BdJFAQNPOyRfRWstJ9E/coyI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "bdd7d8cb8f3157b66a687445afbedf134d19635f"
+        "version": "dbf02325347ef49160c95eaebf6f5e4be83f79a9"
     },
     "gemini-proxy": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,13 +20,13 @@
   };
   codex-proxy-rs = {
     pname = "codex-proxy-rs";
-    version = "bdd7d8cb8f3157b66a687445afbedf134d19635f";
+    version = "dbf02325347ef49160c95eaebf6f5e4be83f79a9";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy-rs";
-      rev = "bdd7d8cb8f3157b66a687445afbedf134d19635f";
+      rev = "dbf02325347ef49160c95eaebf6f5e4be83f79a9";
       fetchSubmodules = false;
-      sha256 = "sha256-Wgt59weDUiiYrtXHrHPQVdsJ5dEVWbZQwAMfOGBMank=";
+      sha256 = "sha256-0piqRoveYyYru9zfX67BdJFAQNPOyRfRWstJ9E/coyI=";
     };
     date = "2026-06-17";
   };


### PR DESCRIPTION
Bumps the `codex-proxy-rs` pin `bdd7d8c → dbf0232` (current `main`), picking up **codex-proxy-rs#13** — the ADR 006 foundation: conversation-identity resolution + reasoning-item capture. Both are **observability-only, no behavior change**; they add tracing fields (`conversation_key_fp`, `conversation_key_source`, `reasoning_items` / `reasoning_encrypted_bytes` / `reasoning_summary_present`) so we can validate identity stability + confirm encrypted reasoning is received against real traffic before building the affinity router (PR2).

## Change
- `_sources/generated.{nix,json}` regenerated via `nvfetcher --filter '^codex-proxy-rs$'` — only the `codex-proxy-rs` entry changed (rev + sha256 + date).
- No upstream `Cargo.lock`/dependency changes → `cargoLock.lockFile` resolution unaffected.

## Test plan
- `nix build .#codex-proxy-rs -L` builds clean; `result/bin/codex-proxy --version` → `codex-proxy 0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)