### PR TITLE
feat(codex-proxy-rs): bump to main @ 607ffc3 (router mode)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -22,7 +22,7 @@
     },
     "codex-proxy-rs": {
         "cargoLock": null,
-        "date": "2026-06-17",
+        "date": "2026-06-18",
         "extract": null,
         "name": "codex-proxy-rs",
         "passthru": null,
@@ -34,12 +34,12 @@
             "name": null,
             "owner": "jmmaloney4",
             "repo": "codex-proxy-rs",
-            "rev": "dbf02325347ef49160c95eaebf6f5e4be83f79a9",
-            "sha256": "sha256-0piqRoveYyYru9zfX67BdJFAQNPOyRfRWstJ9E/coyI=",
+            "rev": "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4",
+            "sha256": "sha256-/r+xgNbSIvudfGF6hID+tl7Gt8dD1J+Wf1DvIf6quDA=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "dbf02325347ef49160c95eaebf6f5e4be83f79a9"
+        "version": "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4"
     },
     "gemini-proxy": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,15 +20,15 @@
   };
   codex-proxy-rs = {
     pname = "codex-proxy-rs";
-    version = "dbf02325347ef49160c95eaebf6f5e4be83f79a9";
+    version = "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy-rs";
-      rev = "dbf02325347ef49160c95eaebf6f5e4be83f79a9";
+      rev = "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4";
       fetchSubmodules = false;
-      sha256 = "sha256-0piqRoveYyYru9zfX67BdJFAQNPOyRfRWstJ9E/coyI=";
+      sha256 = "sha256-/r+xgNbSIvudfGF6hID+tl7Gt8dD1J+Wf1DvIf6quDA=";
     };
-    date = "2026-06-17";
+    date = "2026-06-18";
   };
   gemini-proxy = {
     pname = "gemini-proxy";


### PR DESCRIPTION
Bumps codex-proxy-rs `dbf0232 → 607ffc3`, picking up **codex-proxy-rs#14** (CODEX_PROXY_MODE=router — the conversation→account affinity router). Required so garden's `codex-proxy-router` deployment (garden#901) runs an image that understands router mode.

`nix build .#codex-proxy-rs` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)