### PR TITLE
feat(codex-proxy-rs): bump to main @ e13efb1 (subscription-usage metrics)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -34,12 +34,12 @@
             "name": null,
             "owner": "jmmaloney4",
             "repo": "codex-proxy-rs",
-            "rev": "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4",
-            "sha256": "sha256-/r+xgNbSIvudfGF6hID+tl7Gt8dD1J+Wf1DvIf6quDA=",
+            "rev": "e13efb14dc810a83caf40a642c48427fab3772d0",
+            "sha256": "sha256-MWpbkx1TC1dL/LcfuzGHiyNWgiLgGo3jTUOeHs+JwLs=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4"
+        "version": "e13efb14dc810a83caf40a642c48427fab3772d0"
     },
     "gemini-proxy": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,13 +20,13 @@
   };
   codex-proxy-rs = {
     pname = "codex-proxy-rs";
-    version = "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4";
+    version = "e13efb14dc810a83caf40a642c48427fab3772d0";
     src = fetchFromGitHub {
       owner = "jmmaloney4";
       repo = "codex-proxy-rs";
-      rev = "607ffc34c446e993c9f9d573c3f2a7f8b265d6a4";
+      rev = "e13efb14dc810a83caf40a642c48427fab3772d0";
       fetchSubmodules = false;
-      sha256 = "sha256-/r+xgNbSIvudfGF6hID+tl7Gt8dD1J+Wf1DvIf6quDA=";
+      sha256 = "sha256-MWpbkx1TC1dL/LcfuzGHiyNWgiLgGo3jTUOeHs+JwLs=";
     };
     date = "2026-06-18";
   };


### PR DESCRIPTION
## Summary

nvfetcher repin of `codex-proxy-rs` **607ffc3 → e13efb1**, pulling in jmmaloney4/codex-proxy-rs#15 (merged): the proxy now reads the ChatGPT/Codex subscription rate-limit headers and exposes them as Prometheus gauges on a new open `GET /metrics`, plus `codex.subscription.*` span attributes, labeled by a `CODEX_PROXY_ACCOUNT` alias (codex-proxy-rs ADR 008; garden ADR 101).

This is the "ship the binary" step of ergodicsystems/hq#164 — garden builds its `codex-proxy` image from `jackpkgs.packages.codex-proxy-rs`, so this bump is the prerequisite for the garden deploy-wiring.

## Changes
- `_sources/generated.{json,nix}` only — `codex-proxy-rs` src rev + sha256. No other package touched.
- **No manual vendor hash:** the package uses `cargoLock.lockFile = src + "/Cargo.lock"`, so the new `prometheus` crate (default-features off) vendors from the updated lockfile automatically.

## Test plan
- `nix run github:berberman/nvfetcher -- -f codex-proxy-rs` → clean `607ffc3 → e13efb1` repin (diff scoped to codex-proxy-rs).
- `nix build .#codex-proxy-rs -L` ✅ on darwin (new `Cargo.lock` vendors + compiles).
- Smoke: built binary exposes the new `--account` / `CODEX_PROXY_ACCOUNT` flag with the ADR 008 help text — confirms it's the #15 binary.

## Next (tracked in ergodicsystems/hq#164)
- garden: bump the `jackpkgs` flake input, then add `CODEX_PROXY_ACCOUNT` env + metrics port in `codex-proxy.ts` and the Alloy scrape job → Mimir.

Refs: jmmaloney4/codex-proxy-rs#15, garden ADR 101, ergodicsystems/hq#164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)