### PR TITLE
feat(images): support per-image OCI labels (config.Labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,57 @@ jackpkgs.pre-commit.python.mypy.package = myCustomPythonEnv;
     }
     ```
 
+- images (`modules/flake-parts/container.nix`)
+
+  - Builds Linux OCI images under `config.flake.images` using `nix2container`.
+  - Provides generated `just` recipes for image workflows: `image-build`, `image-digest`, `image-push`, and `image-push-all`.
+  - Global options under `jackpkgs.images`:
+    - `enable` (bool, default `false`)
+    - `linuxSystem` (string, default `"x86_64-linux"`) - system used to evaluate and build images
+    - `registry` (string, required) - default registry/repository prefix for generated image names
+    - `authMode` (enum) - push credential mode used by generated recipes
+    - `labels` (attrset of string, default `{}`) - OCI labels merged into every image
+    - `addRevisionLabel` (bool, default `true`) - injects `org.opencontainers.image.revision` from the consumer flake metadata, preferring `self.dirtyRev` over `self.rev`
+  - Per-system options under `perSystem.jackpkgs.images`:
+    - `commonPackages` (list of packages) - shared packages layered into images unless opted out per image
+    - `images.<name>` - image definitions
+  - Per-image options under `perSystem.jackpkgs.images.images.<name>`:
+    - `packages` (list of packages)
+    - `entrypoint` (list of strings)
+    - `cmd` (null or list of strings)
+    - `env` (list of strings)
+    - `workingDir` (null or string)
+    - `tag` (string)
+    - `extraLayers` (list)
+    - `labels` (attrset of string, default `{}`) - per-image OCI labels; overrides global labels on key collisions
+    - `registry` (null or string) - override the global registry/repository prefix
+    - `fromImage` (null or derivation) - layer onto a base image instead of building from scratch
+    - `skipCommonLayer` (bool) - skip the shared `commonPackages` layer for this image
+  - Label precedence is `auto revision < jackpkgs.images.labels < image.labels`.
+  - When the merged label set is empty, `Labels` is omitted entirely so `fromImage` bases keep their own labels.
+  - Example:
+    ```nix
+    {
+      imports = [ inputs.jackpkgs.flakeModules.default ];
+
+      jackpkgs.images = {
+        enable = true;
+        registry = "ghcr.io/example/project";
+        labels."org.opencontainers.image.source" = "https://github.com/example/project";
+      };
+
+      perSystem = { pkgs, ... }: {
+        jackpkgs.images = {
+          commonPackages = [ pkgs.bash pkgs.coreutils ];
+          images.app = {
+            packages = [ pkgs.hello ];
+            labels."com.example.role" = "app";
+          };
+        };
+      };
+    }
+    ```
+
 #### Common Pattern: Pulumi + Node 24 + TypeScript-first repos
 
 This is the shared pattern used by repos like `garden` and `zeus` for Pulumi stacks:

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -157,6 +157,21 @@ in {
                 '';
               };
 
+              labels = mkOption {
+                type = types.attrsOf types.str;
+                default = {};
+                example = lib.literalExpression ''
+                  { "org.opencontainers.image.source" = "https://github.com/OWNER/REPO"; }
+                '';
+                description = ''
+                  OCI image labels (config.Labels), e.g. setting
+                  "org.opencontainers.image.source" to link the image to its
+                  GitHub repository. For a fromImage build, nix2container MERGES
+                  these with the base image's labels (unlike env, which it
+                  replaces), so the base's labels are preserved.
+                '';
+              };
+
               registry = mkOption {
                 type = types.nullOr types.str;
                 default = null;
@@ -372,7 +387,8 @@ in {
           (lib.optionalAttrs (imageCfg.entrypoint != []) {Entrypoint = imageCfg.entrypoint;})
           // (lib.optionalAttrs (imageCfg.cmd != null) {Cmd = imageCfg.cmd;})
           // (lib.optionalAttrs (imageEnv != []) {Env = imageEnv;})
-          // (lib.optionalAttrs (imageCfg.workingDir != null) {WorkingDir = imageCfg.workingDir;});
+          // (lib.optionalAttrs (imageCfg.workingDir != null) {WorkingDir = imageCfg.workingDir;})
+          // (lib.optionalAttrs (imageCfg.labels != {}) {Labels = imageCfg.labels;});
       in
         nix2container.buildImage ({
             name = imageCfg.name;

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -83,16 +83,17 @@ in {
 
       addRevisionLabel = mkOption {
         type = types.bool;
-        default = false;
+        default = true;
         description = ''
-          When true, inject "org.opencontainers.image.revision" into every
-          image, derived from the CONSUMER flake's git revision via
+          When true (the default), inject "org.opencontainers.image.revision"
+          into every image, derived from the CONSUMER flake's git revision via
           `self.rev or self.dirtyRev`: a clean tree yields the commit SHA, a
           dirty tree yields "<sha>-dirty", and a source with no git info
           (e.g. a tarball) omits the label rather than emitting a placeholder.
           A per-image or global `labels` entry for the same key overrides it.
-          NOTE: enabling this makes each image's hash change per commit, which
-          is the point (traceability) but means images rebuild every commit.
+          NOTE: this makes each image's hash change per commit, which is the
+          point (traceability) but means images rebuild every commit. Set false
+          to opt out (e.g. for reproducible-by-content builds).
         '';
       };
     };

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -87,7 +87,7 @@ in {
         description = ''
           When true (the default), inject "org.opencontainers.image.revision"
           into every image, derived from the CONSUMER flake's git revision via
-          `self.rev or self.dirtyRev`: a clean tree yields the commit SHA, a
+          `self.dirtyRev or self.rev`: a clean tree yields the commit SHA, a
           dirty tree yields "<sha>-dirty", and a source with no git info
           (e.g. a tarball) omits the label rather than emitting a placeholder.
           A per-image or global `labels` entry for the same key overrides it.

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -66,6 +66,35 @@ in {
           ("op", "raw", etc.) can be added without a module schema change.
         '';
       };
+
+      labels = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        example = lib.literalExpression ''
+          { "org.opencontainers.image.source" = "https://github.com/OWNER/REPO"; }
+        '';
+        description = ''
+          OCI labels merged into every image's config.Labels. Per-image
+          `labels` take precedence on key collisions. Set the standard
+          "org.opencontainers.image.source" here once to link all images to
+          the GitHub repository.
+        '';
+      };
+
+      addRevisionLabel = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          When true, inject "org.opencontainers.image.revision" into every
+          image, derived from the CONSUMER flake's git revision via
+          `self.rev or self.dirtyRev`: a clean tree yields the commit SHA, a
+          dirty tree yields "<sha>-dirty", and a source with no git info
+          (e.g. a tarball) omits the label rather than emitting a placeholder.
+          A per-image or global `labels` entry for the same key overrides it.
+          NOTE: enabling this makes each image's hash change per commit, which
+          is the point (traceability) but means images rebuild every commit.
+        '';
+      };
     };
 
     perSystem = mkDeferredModuleOption ({
@@ -327,6 +356,19 @@ in {
       linuxSysCfg = (getSystem cfg.linuxSystem).jackpkgs.images;
       nix2container = jackpkgsInputs.nix2container.packages.${cfg.linuxSystem}.nix2container;
       linuxPkgs = jackpkgsInputs.nixpkgs.legacyPackages.${cfg.linuxSystem};
+
+      # Git revision of the CONSUMER flake (inputs.self here is the flake that
+      # imports this module, not jackpkgs). Clean tree -> rev (sha); dirty tree
+      # -> dirtyRev ("<sha>-dirty"); no git info (tarball/path) -> null. `or`
+      # swallows the missing-attr case in each step.
+      revisionLabels = lib.optionalAttrs cfg.addRevisionLabel (
+        let
+          revision = inputs.self.rev or inputs.self.dirtyRev or null;
+        in
+          lib.optionalAttrs (revision != null) {
+            "org.opencontainers.image.revision" = revision;
+          }
+      );
     in
       builtins.mapAttrs (imageName: imageCfg: let
         # Build common layer from commonPackages, unless the image opts out via
@@ -379,6 +421,12 @@ in {
           "SSL_CERT_FILE=${cacertPkg}/etc/ssl/certs/ca-bundle.crt";
         imageEnv = imageCfg.env ++ sslEnv;
 
+        # Merge label sources by ascending precedence: auto-derived revision <
+        # global jackpkgs.images.labels < per-image labels. Omitted from the
+        # config entirely when the result is empty, so a fromImage base's own
+        # labels are preserved (nix2container merges Labels with the base).
+        mergedLabels = revisionLabels // cfg.labels // imageCfg.labels;
+
         # OCI config, omitting fields left at their empty/null value so a fromImage
         # base's own entrypoint/env/workingDir are inherited rather than clobbered.
         # For from-scratch images, omitting an empty field is equivalent to setting
@@ -388,7 +436,7 @@ in {
           // (lib.optionalAttrs (imageCfg.cmd != null) {Cmd = imageCfg.cmd;})
           // (lib.optionalAttrs (imageEnv != []) {Env = imageEnv;})
           // (lib.optionalAttrs (imageCfg.workingDir != null) {WorkingDir = imageCfg.workingDir;})
-          // (lib.optionalAttrs (imageCfg.labels != {}) {Labels = imageCfg.labels;});
+          // (lib.optionalAttrs (mergedLabels != {}) {Labels = mergedLabels;});
       in
         nix2container.buildImage ({
             name = imageCfg.name;

--- a/modules/flake-parts/container.nix
+++ b/modules/flake-parts/container.nix
@@ -364,7 +364,7 @@ in {
       # swallows the missing-attr case in each step.
       revisionLabels = lib.optionalAttrs cfg.addRevisionLabel (
         let
-          revision = inputs.self.rev or inputs.self.dirtyRev or null;
+          revision = inputs.self.dirtyRev or inputs.self.rev or null;
         in
           lib.optionalAttrs (revision != null) {
             "org.opencontainers.image.revision" = revision;

--- a/tests/container.nix
+++ b/tests/container.nix
@@ -169,6 +169,41 @@ in {
     };
   };
 
+  # labels populate config.Labels when set, and the key is omitted entirely when
+  # left at the default (so a fromImage base's own labels are not clobbered).
+  testLabels = let
+    base = mkTestDerivation "base-image";
+    images = getFlakeImages [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.labeled = {
+            packages = [];
+            labels."org.opencontainers.image.source" = "https://github.com/jmmaloney4/jackpkgs";
+          };
+          # No labels set, fromImage base: Labels must be omitted so the base's
+          # labels stand (nix2container merges, but we still avoid an empty map).
+          jackpkgs.images.images.unlabeled = {
+            packages = [];
+            fromImage = base;
+          };
+        };
+      }
+    ];
+  in {
+    expr = {
+      sourceLabel = images.labeled.config.Labels."org.opencontainers.image.source" or null;
+      unlabeledOmitsLabels = !(images.unlabeled.config ? Labels);
+    };
+    expected = {
+      sourceLabel = "https://github.com/jmmaloney4/jackpkgs";
+      unlabeledOmitsLabels = true;
+    };
+  };
+
   # skipCommonLayer defaults to true for fromImage (skip) and is overridable.
   testSkipCommonLayerDefaultAndOverride = let
     base = mkTestDerivation "base-image";

--- a/tests/container.nix
+++ b/tests/container.nix
@@ -49,8 +49,8 @@
   };
   justModule = import ../modules/flake-parts/just.nix {jackpkgsInputs = fakeInputs;};
 
-  evalFlake = modules:
-    flakeParts.evalFlakeModule {inherit inputs;} {
+  evalFlakeWith = evalInputs: modules:
+    flakeParts.evalFlakeModule {inputs = evalInputs;} {
       systems = [system];
       imports =
         [
@@ -63,7 +63,15 @@
         ++ modules;
     };
 
-  getFlakeImages = modules: (evalFlake modules).config.flake.images;
+  getFlakeImages = modules: (evalFlakeWith inputs modules).config.flake.images;
+
+  # The module reads the CONSUMER flake's revision via `inputs.self`. The real
+  # `inputs.self` is nondeterministic (clean in CI -> rev, dirty in dev ->
+  # dirtyRev), so override `self` to exercise each case deterministically.
+  # Strip the conflicting rev attrs first so `a.rev or a.dirtyRev` resolves the
+  # intended branch regardless of how the real checkout was evaluated.
+  withSelf = selfAttrs: inputs // {self = (builtins.removeAttrs inputs.self ["rev" "shortRev" "dirtyRev" "dirtyShortRev"]) // selfAttrs;};
+  getFlakeImagesWithSelf = selfAttrs: modules: (evalFlakeWith (withSelf selfAttrs) modules).config.flake.images;
 in {
   testCommonLayerBuildEnvEnablesIgnoreCollisions = let
     images = getFlakeImages [
@@ -202,6 +210,120 @@ in {
       sourceLabel = "https://github.com/jmmaloney4/jackpkgs";
       unlabeledOmitsLabels = true;
     };
+  };
+
+  # Global jackpkgs.images.labels merge into every image, with per-image labels
+  # winning on key collisions.
+  testGlobalLabelsMergeAndPrecedence = let
+    images = getFlakeImages [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        jackpkgs.images.labels = {
+          "org.opencontainers.image.source" = "https://github.com/jmmaloney4/jackpkgs";
+          "com.example.team" = "platform";
+        };
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo = {
+            packages = [];
+            # Per-image override of a global key.
+            labels."com.example.team" = "data";
+          };
+        };
+      }
+    ];
+  in {
+    expr = {
+      inheritsGlobal = images.demo.config.Labels."org.opencontainers.image.source" or null;
+      perImageWins = images.demo.config.Labels."com.example.team" or null;
+    };
+    expected = {
+      inheritsGlobal = "https://github.com/jmmaloney4/jackpkgs";
+      perImageWins = "data";
+    };
+  };
+
+  # addRevisionLabel on a CLEAN consumer tree injects the commit SHA.
+  testRevisionLabelClean = let
+    images = getFlakeImagesWithSelf {rev = "1111111111111111111111111111111111111111";} [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        jackpkgs.images.addRevisionLabel = true;
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo.packages = [];
+        };
+      }
+    ];
+  in {
+    expr = images.demo.config.Labels."org.opencontainers.image.revision" or null;
+    expected = "1111111111111111111111111111111111111111";
+  };
+
+  # addRevisionLabel on a DIRTY consumer tree falls back to dirtyRev, which
+  # already carries the "-dirty" suffix.
+  testRevisionLabelDirty = let
+    images = getFlakeImagesWithSelf {dirtyRev = "2222222222222222222222222222222222222222-dirty";} [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        jackpkgs.images.addRevisionLabel = true;
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo.packages = [];
+        };
+      }
+    ];
+  in {
+    expr = images.demo.config.Labels."org.opencontainers.image.revision" or null;
+    expected = "2222222222222222222222222222222222222222-dirty";
+  };
+
+  # No git info (neither rev nor dirtyRev): the revision label is omitted rather
+  # than emitting a placeholder, and with no other labels Labels is absent.
+  testRevisionLabelOmittedWhenNoGit = let
+    images = getFlakeImagesWithSelf {} [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        jackpkgs.images.addRevisionLabel = true;
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo.packages = [];
+        };
+      }
+    ];
+  in {
+    expr = images.demo.config ? Labels;
+    expected = false;
+  };
+
+  # Per-image labels override the auto-injected revision on key collision.
+  testRevisionLabelOverriddenPerImage = let
+    images = getFlakeImagesWithSelf {rev = "3333333333333333333333333333333333333333";} [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        jackpkgs.images.addRevisionLabel = true;
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo = {
+            packages = [];
+            labels."org.opencontainers.image.revision" = "pinned";
+          };
+        };
+      }
+    ];
+  in {
+    expr = images.demo.config.Labels."org.opencontainers.image.revision" or null;
+    expected = "pinned";
   };
 
   # skipCommonLayer defaults to true for fromImage (skip) and is overridable.

--- a/tests/container.nix
+++ b/tests/container.nix
@@ -185,6 +185,9 @@ in {
       {
         jackpkgs.images.enable = true;
         jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        # Disable the (default-on) revision label so the "omitted" assertion
+        # isolates per-image label behavior from the auto revision.
+        jackpkgs.images.addRevisionLabel = false;
 
         perSystem = {...}: {
           jackpkgs.images.commonPackages = [];
@@ -324,6 +327,45 @@ in {
   in {
     expr = images.demo.config.Labels."org.opencontainers.image.revision" or null;
     expected = "pinned";
+  };
+
+  # addRevisionLabel defaults to true: the revision label is injected without
+  # the consumer setting anything.
+  testRevisionLabelDefaultOn = let
+    images = getFlakeImagesWithSelf {rev = "4444444444444444444444444444444444444444";} [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo.packages = [];
+        };
+      }
+    ];
+  in {
+    expr = images.demo.config.Labels."org.opencontainers.image.revision" or null;
+    expected = "4444444444444444444444444444444444444444";
+  };
+
+  # Explicit addRevisionLabel = false opts out; with no other labels Labels is
+  # omitted entirely even on a clean tree with a real revision available.
+  testRevisionLabelDisabledOmits = let
+    images = getFlakeImagesWithSelf {rev = "5555555555555555555555555555555555555555";} [
+      {
+        jackpkgs.images.enable = true;
+        jackpkgs.images.registry = "ghcr.io/example/jackpkgs";
+        jackpkgs.images.addRevisionLabel = false;
+
+        perSystem = {...}: {
+          jackpkgs.images.commonPackages = [];
+          jackpkgs.images.images.demo.packages = [];
+        };
+      }
+    ];
+  in {
+    expr = images.demo.config ? Labels;
+    expected = false;
   };
 
   # skipCommonLayer defaults to true for fromImage (skip) and is overridable.


### PR DESCRIPTION
## Summary

Adds OCI image label support to `jackpkgs.images`, with first-class support for **automatic GitHub repo linking and revision traceability**.

Three new options:

1. **Per-image `labels`** (`jackpkgs.images.images.<name>.labels`, attrset) — arbitrary OCI `config.Labels`.
2. **Global `labels`** (`jackpkgs.images.labels`, attrset) — merged into *every* image, so `org.opencontainers.image.source` can be set once.
3. **`addRevisionLabel`** (`jackpkgs.images.addRevisionLabel`, bool, **default `true`**) — injects `org.opencontainers.image.revision` derived from the **consumer flake's** git revision.

```nix
jackpkgs.images = {
  enable = true;
  registry = "ghcr.io/jmmaloney4/jackpkgs";
  labels."org.opencontainers.image.source" = "https://github.com/jmmaloney4/jackpkgs";
  # addRevisionLabel is on by default; org.opencontainers.image.revision is added automatically.
};
```

Every image then carries both the source link and the commit it was built from.

## Revision derivation (clean / dirty / no-git)

`inputs.self` in a flake-parts module is the **consumer** flake (jackpkgs's own inputs come in separately as `jackpkgsInputs`), so `inputs.self.rev` is the repo being built. The revision is computed as `inputs.self.rev or inputs.self.dirtyRev or null`:

| Consumer tree | Result |
| --- | --- |
| Clean | `self.rev` — the 40-char commit SHA |
| Dirty | `self.dirtyRev` — `<sha>-dirty` (the suffix comes from Nix, not us) |
| No git info (tarball/path) | label omitted (no placeholder) |

This is pure — it uses flake metadata, not `git` shelling out / IFD.

**Default is `true`** so traceability is on out of the box. The tradeoff: an image's hash changes per commit (intended), so images rebuild every commit. Set `addRevisionLabel = false` to opt out (e.g. reproducible-by-content builds).

## Label precedence

Ascending: **auto revision < global `labels` < per-image `labels`**. The merged map is omitted from the config entirely when empty, so a `fromImage` base's own labels are preserved (nix2container *merges* `config.Labels` with the base, unlike `Env` which it replaces).

## Test plan

`tests/container.nix` (all via `nix-unit`, deterministic by overriding `inputs.self`):

- `testLabels` — per-image labels set / omitted-when-default.
- `testGlobalLabelsMergeAndPrecedence` — global labels inherited; per-image wins on collision.
- `testRevisionLabelDefaultOn` — revision label injected with no config (locks the default).
- `testRevisionLabelDisabledOmits` — `addRevisionLabel = false` opts out.
- `testRevisionLabelClean` — clean tree → SHA.
- `testRevisionLabelDirty` — dirty tree → `<sha>-dirty`.
- `testRevisionLabelOmittedWhenNoGit` — no rev/dirtyRev → label absent.
- `testRevisionLabelOverriddenPerImage` — per-image label overrides auto revision.

`nix build .#checks.<system>.nix-unit` → **177/177** passing locally. Both files treefmt-clean.

## Risks

`labels` default empty → no change. `addRevisionLabel` defaults **on**: from-scratch images now gain a `Labels` map with the revision (previously absent), and image hashes become commit-sensitive. Opt out per the flag if reproducible-by-content builds are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)