### PR TITLE
ci: bump sector7 reusable workflows to a04c7f39

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,4 +8,4 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@2e5bb3f84ad97df9eb8c914987047e6ba29ec508 # main
+    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@2e5bb3f84ad97df9eb8c914987047e6ba29ec508 # main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
        !contains(github.event.comment.body, 'no claude review') &&
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
-    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@2e5bb3f84ad97df9eb8c914987047e6ba29ec508 # main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/sector7/.github/workflows/claude.yml@2e5bb3f84ad97df9eb8c914987047e6ba29ec508 # main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/sector7/.github/workflows/nix.yml@2e5bb3f84ad97df9eb8c914987047e6ba29ec508 # main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}


### PR DESCRIPTION
Advances the pinned sector7 reusable-workflow SHAs to current sector7 `main` (`a04c7f39`), which includes the nix-setup host-daemon flakes fix (jmmaloney4/sector7#300).

Mechanical pin bump only — every changed line is a sector7 `uses:` SHA on a `# main`-tagged reusable-workflow reference; no other action pins touched.

`2e5bb3f8` → `a04c7f39` across 5 files:
- `.github/workflows/add-to-project.yml`
- `.github/workflows/adr-management.yml`
- `.github/workflows/claude-review.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/nix.yml`

Interface changes since the old pin are additive/optional only, so this is backwards-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)