### PR TITLE
ci: run ADR check on self-hosted runner

### DIFF
--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main
     with:
-      runs-on: ubuntu-latest
+      runs-on: self-hosted
       repository: ${{ github.repository }}
       ref: ${{ github.event.pull_request.head.sha }}
       base_ref: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## What

Change the `runs-on` input the `adr-management` caller passes to sector7's reusable workflow from `ubuntu-latest` to `self-hosted`, moving the ADR check off GitHub-hosted runners onto our self-hosted ARC fleet.

## Why

Every other jackpkgs workflow (`claude`, `claude-review`, `nix`, `add-to-project`) already runs self-hosted because they omit `runs-on` and inherit sector7's reusable-workflow default of `self-hosted`. Only the ADR caller explicitly pinned `ubuntu-latest`. This aligns it with the rest of the repo.

The target label is the bare string `self-hosted` — jackpkgs's ARC runner scope advertises exactly `["self-hosted"]`, so any other label (e.g. an array or `room-of-requirement`) would leave the job queued forever.

## Change

One line, `.github/workflows/adr-management.yml`:

```diff
-      runs-on: ubuntu-latest
+      runs-on: self-hosted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)