### PR TITLE
feat(dbn-cli): package databento dbn CLI

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -41,6 +41,27 @@
         },
         "version": "e13efb14dc810a83caf40a642c48427fab3772d0"
     },
+    "dbn-cli": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "dbn-cli",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "databento",
+            "repo": "dbn",
+            "rev": "v0.61.0",
+            "sha256": "sha256-PMfTgyfLg0O61CypAN+l3porXuOE+bK777J9i4QE+W8=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "v0.61.0"
+    },
     "gemini-proxy": {
         "cargoLock": null,
         "date": "2026-03-09",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -30,6 +30,17 @@
     };
     date = "2026-06-18";
   };
+  dbn-cli = {
+    pname = "dbn-cli";
+    version = "v0.61.0";
+    src = fetchFromGitHub {
+      owner = "databento";
+      repo = "dbn";
+      rev = "v0.61.0";
+      fetchSubmodules = false;
+      sha256 = "sha256-PMfTgyfLg0O61CypAN+l3porXuOE+bK777J9i4QE+W8=";
+    };
+  };
   gemini-proxy = {
     pname = "gemini-proxy";
     version = "5f701a244ed3c4699e6c1b0550bd50e961601ebe";

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,9 @@
           codex-proxy-rs = pkgs.callPackage ./pkgs/codex-proxy-rs {
             inherit (nvfetcherSources.codex-proxy-rs) src version;
           };
+          dbn-cli = pkgs.callPackage ./pkgs/dbn-cli {
+            inherit (nvfetcherSources.dbn-cli) src version;
+          };
           docfx = pkgs.callPackage ./pkgs/docfx {};
           gemini-proxy = pkgsWithBun2nix.callPackage ./pkgs/gemini-proxy {
             inherit (nvfetcherSources.gemini-proxy) src version;

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -8,6 +8,10 @@ src.github = "alanvardy/tod"
 fetch.github = "alanvardy/tod"
 cargo_lock = ["Cargo.lock"]
 
+[dbn-cli]
+src.github = "databento/dbn"
+fetch.github = "databento/dbn"
+
 [spooktacular]
 src.git = "https://github.com/Spooky-Labs/spooktacular"
 fetch.github = "Spooky-Labs/spooktacular"

--- a/overlay.nix
+++ b/overlay.nix
@@ -32,6 +32,9 @@ else let
     codex-proxy-rs = super.callPackage ./pkgs/codex-proxy-rs {
       inherit (nvfetcherSources.codex-proxy-rs) src version;
     };
+    dbn-cli = super.callPackage ./pkgs/dbn-cli {
+      inherit (nvfetcherSources.dbn-cli) src version;
+    };
     docfx = super.callPackage ./pkgs/docfx {};
     gemini-proxy = superWithBun2nix.callPackage ./pkgs/gemini-proxy {
       inherit (nvfetcherSources.gemini-proxy) src version;

--- a/pkgs/dbn-cli/default.nix
+++ b/pkgs/dbn-cli/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  # From nvfetcher
+  src,
+  version,
+  pkg-config,
+  openssl,
+}:
+rustPlatform.buildRustPackage {
+  pname = "dbn-cli";
+  inherit version src;
+
+  # The workspace ships its own Cargo.lock and depends only on crates.io
+  # registry packages (no git dependencies), so the lockfile can be read
+  # straight from the fetched source with no outputHashes.
+  cargoLock.lockFile = src + "/Cargo.lock";
+
+  # Build only the CLI crate from the workspace.
+  buildAndTestSubdir = "rust/dbn-cli";
+
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [openssl];
+
+  # Link against the nix-provided OpenSSL rather than a vendored copy.
+  OPENSSL_NO_VENDOR = "1";
+
+  meta = {
+    description = "CLI tool for working with Databento Binary Encoding (DBN) files and streams";
+    homepage = "https://github.com/databento/dbn";
+    license = lib.licenses.asl20;
+    maintainers = [];
+    platforms = lib.platforms.all;
+    mainProgram = "dbn";
+  };
+}


### PR DESCRIPTION
## Summary

Adds the **`dbn`** CLI ([databento/dbn](https://github.com/databento/dbn), the `rust/dbn-cli` workspace crate) as a jackpkgs package, tracked via nvfetcher at **v0.61.0**.

The crate's `Cargo.lock` contains only crates.io registry deps (no `git+` sources), so the lockfile is read straight from the fetched source (`cargoLock.lockFile = src + "/Cargo.lock"`) — mirroring the existing `codex-proxy-rs` package and avoiding nvfetcher's `cargo_lock` extraction.

## Why

`dbn-cli` currently lives in `cavinsresearch/zeus` as an external-source Rust build. Its prebuilt output is the one path in zeus's flake that hits a **poisoned attic cache entry** — every CI run fails substitution with a NAR hash mismatch:

```
error: hash mismatch importing path '/nix/store/1dffcdx…-dbn-cli-v0.36.1';
   specified: sha256-BHLjg66…
   got:       sha256-YFCUcyk…
error: … no substituter that can build it
```

Because `nix-fast-build` runs without `--fallback`, the corrupted cache entry reddens every zeus PR's nix run instead of rebuilding from source. Relocating the package here gives it a fresh output path and a single shared cached build. The zeus side (consume `inputs'.jackpkgs.packages.dbn-cli`, delete the local definition) follows in a companion PR.

## Test plan

- [x] `nix build .#dbn-cli` succeeds; upstream's 80 crate tests pass in `cargoCheckHook`
- [x] `dbn --version` → `dbn 0.61.0`
- [x] `nix eval .#packages.aarch64-darwin.dbn-cli.pname` → `dbn-cli` (overlay + flake outputs both expose it)
- [x] `nix fmt --ci` clean on changed files
- [x] `_sources/generated.{nix,json}` diff is dbn-cli-only (other entries byte-identical)

## Notes

- nvfetcher's `cargo_lock` extraction is broken on darwin in this environment (fails on the existing `tod`/`nautilus-trader` entries too); the dbn-cli `_sources` entry was generated by temporarily isolating it, and the other entries restored from `HEAD` unchanged. Linux CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)